### PR TITLE
Refactor/rename pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,16 @@ make init                     - Run pipelex init
 make codex-tests              - Run tests for Codex (exit on first failure) (no inference, no codex_disabled)
 make gha-tests		          - Run tests for github actions (exit on first failure) (no inference, no gha_disabled)
 make test                     - Run unit tests (no inference)
+make test-xdist               - Run unit tests with xdist (no inference)
+make t                        - Shorthand -> test-xdist
+make test-quiet               - Run unit tests without prints (no inference)
+make tq                       - Shorthand -> test-quiet
 make test-with-prints         - Run tests with prints (no inference)
-make t                        - Shorthand -> test-with-prints
+make tp                       - Shorthand -> test-with-prints
 make test-inference           - Run unit tests only for inference (with prints)
 make ti                       - Shorthand -> test-inference
+make test-ocr                 - Run unit tests only for ocr (with prints)
+make to                       - Shorthand -> test-ocr
 make test-imgg                - Run unit tests only for imgg (with prints)
 make test-g					  - Shorthand -> test-imgg
 
@@ -83,7 +89,17 @@ make fix-unused-imports       - Fix unused imports with ruff
 endef
 export HELP
 
-.PHONY: all help env lock install update format lint pyright mypy cleanderived cleanenv validate v codex-tests gha-tests test test-with-prints test-inference t ti test-imgg tg test-ocr tocheck cc li merge-check-ruff-lint merge-check-ruff-format merge-check-mypy check-unused-imports fix-unused-imports check-uv
+.PHONY: all help env lock install update format lint pyright mypy cleanderived cleanenv validate v codex-tests gha-tests test test-xdist t test-with-prints tp test-inference ti test-imgg tg test-ocr tocheck cc li merge-check-ruff-lint merge-check-ruff-format merge-check-mypy check-unused-imports fix-unused-imports check-uv
+.PHONY: \
+	all help env lock install update build \
+	format lint pyright mypy \
+	cleanderived cleanenv cleanlibraries cleanall \
+	test test-xdist t test-quiet tq test-with-prints tp test-inference ti \
+	test-imgg tg test-ocr to codex-tests gha-tests \
+	run-all-tests run-manual-trigger-gha-tests run-gha_disabled-tests \
+	validate v check c cc \
+	merge-check-ruff-lint merge-check-ruff-format merge-check-mypy merge-check-pyright \
+	li check-unused-imports fix-unused-imports check-uv check-TODOs
 
 all help:
 	@echo "$$HELP"
@@ -218,29 +234,53 @@ test: env
 	$(call PRINT_TITLE,"Unit testing without prints but displaying logs via pytest for WARNING level and above")
 	@echo "• Running unit tests"
 	@if [ -n "$(TEST)" ]; then \
-		$(VENV_PYTEST) -o log_cli=true -o log_level=WARNING -k "$(TEST)" $(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,-v)); \
+		$(VENV_PYTEST) -s -o log_cli=true -o log_level=WARNING -k "$(TEST)" $(if $(filter 1,$(VERBOSE)),-v,$(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,))); \
 	else \
-		$(VENV_PYTEST) -o log_cli=true -o log_level=WARNING $(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,-v)); \
+		$(VENV_PYTEST) -s -o log_cli=true -o log_level=WARNING $(if $(filter 1,$(VERBOSE)),-v,$(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,))); \
 	fi
+
+test-xdist: env
+	$(call PRINT_TITLE,"Unit testing without prints but displaying logs via pytest for WARNING level and above")
+	@echo "• Running unit tests"
+	@if [ -n "$(TEST)" ]; then \
+		$(VENV_PYTEST) -n auto -o log_level=WARNING -k "$(TEST)" $(if $(filter 1,$(VERBOSE)),-v,$(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,))); \
+	else \
+		$(VENV_PYTEST) -n auto -o log_level=WARNING $(if $(filter 1,$(VERBOSE)),-v,$(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,))); \
+	fi
+
+t: test-xdist
+	@echo "> done: t = test-xdist"
+
+test-quiet: env
+	$(call PRINT_TITLE,"Unit testing without prints but displaying logs via pytest for WARNING level and above")
+	@echo "• Running unit tests"
+	@if [ -n "$(TEST)" ]; then \
+		$(VENV_PYTEST) -o log_cli=true -o log_level=WARNING -k "$(TEST)" $(if $(filter 1,$(VERBOSE)),-v,$(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,))); \
+	else \
+		$(VENV_PYTEST) -o log_cli=true -o log_level=WARNING $(if $(filter 1,$(VERBOSE)),-v,$(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,))); \
+	fi
+
+tq: test-quiet
+	@echo "> done: tq = test-quiet"
 
 test-with-prints: env
 	$(call PRINT_TITLE,"Unit testing with prints and our rich logs")
-	@echo "• Running unit tests using `$(VENV_PYTEST)`"
+	@echo "• Running unit tests"
 	@if [ -n "$(TEST)" ]; then \
-		$(VENV_PYTEST) -s -k "$(TEST)" $(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,-v)); \
+		$(VENV_PYTEST) -s -k "$(TEST)" $(if $(filter 1,$(VERBOSE)),-v,$(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,))); \
 	else \
-		$(VENV_PYTEST) -s $(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,-v)); \
+		$(VENV_PYTEST) -s $(if $(filter 1,$(VERBOSE)),-v,$(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,))); \
 	fi
 
-t: test-with-prints
-	@echo "> done: t = test-with-prints"
+tp: test-with-prints
+	@echo "> done: tp = test-with-prints"
 
 test-inference: env
 	$(call PRINT_TITLE,"Unit testing")
 	@if [ -n "$(TEST)" ]; then \
-		$(VENV_PYTEST) --exitfirst -m "inference and not imgg" -s -k "$(TEST)" $(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,-v)); \
+		$(VENV_PYTEST) --exitfirst -m "inference and not imgg" -s -k "$(TEST)" $(if $(filter 1,$(VERBOSE)),-v,$(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,))); \
 	else \
-		$(VENV_PYTEST) --exitfirst -m "inference and not imgg" -s $(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,-v)); \
+		$(VENV_PYTEST) --exitfirst -m "inference and not imgg" -s $(if $(filter 1,$(VERBOSE)),-v,$(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,))); \
 	fi
 
 ti: test-inference
@@ -249,9 +289,9 @@ ti: test-inference
 test-ocr: env
 	$(call PRINT_TITLE,"Unit testing ocr")
 	@if [ -n "$(TEST)" ]; then \
-		$(VENV_PYTEST) --exitfirst -m "ocr" -s -k "$(TEST)" $(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,-v)); \
+		$(VENV_PYTEST) --exitfirst -m "ocr" -s -k "$(TEST)" $(if $(filter 1,$(VERBOSE)),-v,$(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,))); \
 	else \
-		$(VENV_PYTEST) --exitfirst -m "ocr" -s $(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,-v)); \
+		$(VENV_PYTEST) --exitfirst -m "ocr" -s $(if $(filter 1,$(VERBOSE)),-v,$(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,))); \
 	fi
 
 to: test-ocr
@@ -260,9 +300,9 @@ to: test-ocr
 test-imgg: env
 	$(call PRINT_TITLE,"Unit testing")
 	@if [ -n "$(TEST)" ]; then \
-		$(VENV_PYTEST) --exitfirst -m "imgg" -s -k "$(TEST)" $(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,-v)); \
+		$(VENV_PYTEST) --exitfirst -m "imgg" -s -k "$(TEST)" $(if $(filter 1,$(VERBOSE)),-v,$(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,))); \
 	else \
-		$(VENV_PYTEST) --exitfirst -m "imgg" -s $(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,-v)); \
+		$(VENV_PYTEST) --exitfirst -m "imgg" -s $(if $(filter 1,$(VERBOSE)),-v,$(if $(filter 2,$(VERBOSE)),-vv,$(if $(filter 3,$(VERBOSE)),-vvv,))); \
 	fi
 
 tg: test-imgg
@@ -333,6 +373,11 @@ v: init validate
 
 li: lock install
 	@echo "> done: lock install"
+
+check-TODOs: env
+	$(call PRINT_TITLE,"Checking for TODOs")
+	$(VENV_RUFF) check --select=TD -v .
+
 
 fix-unused-imports: env
 	$(call PRINT_TITLE,"Fixing unused imports")

--- a/Makefile
+++ b/Makefile
@@ -128,13 +128,15 @@ env: check-uv
 
 init: env
 	$(call PRINT_TITLE,"Running pipelex init")
-	$(VENV_PIPELEX) init
+	$(VENV_PIPELEX) init libraries
+	$(VENV_PIPELEX) init config
 
 install: env
 	$(call PRINT_TITLE,"Installing dependencies")
 	@. $(VIRTUAL_ENV)/bin/activate && \
 	uv sync --all-extras && \
-	$(VENV_PIPELEX) init && \
+	$(VENV_PIPELEX) init libraries && \
+	$(VENV_PIPELEX) init config && \
 	echo "Installed Pipelex cookbook dependencies in ${VIRTUAL_ENV} and initialized Pipelex libraries";
 
 lock: env

--- a/core/wip/README.md
+++ b/core/wip/README.md
@@ -1,5 +1,5 @@
 # WIP samples
 
-## Test the new execute_mission API
+## Test the new execute_pipeline API
 
-- it tracks costs related to a specific mission_id
+- it tracks costs related to a specific pipeline_run_id

--- a/core/wip/summarize_execute_pipeline.py
+++ b/core/wip/summarize_execute_pipeline.py
@@ -3,26 +3,26 @@ import asyncio
 from pipelex import pretty_print
 from pipelex.core.working_memory_factory import WorkingMemoryFactory
 from pipelex.hub import get_report_delegate
-from pipelex.mission.execute import execute_mission
 from pipelex.pipelex import Pipelex
+from pipelex.pipeline.execute import execute_pipeline
 
 
-async def summarize_by_mission(text: str) -> str:
+async def summarize_execute_pipeline(text: str) -> str:
     # Load the working memory with the text
     working_memory = WorkingMemoryFactory.make_from_text(text=text)
 
     # Run the pipe
-    pipe_output, mission_id = await execute_mission(
+    pipe_output, pipeline_run_id = await execute_pipeline(
         pipe_code="summarize_by_steps",
         working_memory=working_memory,
     )
 
     summary_text = pipe_output.main_stuff_as_str
 
-    pretty_print(mission_id, title="Mission ID")
+    pretty_print(pipeline_run_id, title="Pipeline run id")
 
     # Get the report (tokens used and cost)
-    get_report_delegate().generate_report(mission_id=mission_id)
+    get_report_delegate().generate_report(pipeline_run_id=pipeline_run_id)
     return summary_text
 
 
@@ -33,7 +33,7 @@ with open("assets/sample_text_3.txt", "r", encoding="utf-8") as f:
 # start Pipelex
 Pipelex.make()
 # run sample using asyncio
-summary_text = asyncio.run(summarize_by_mission(text))
+summary_text = asyncio.run(summarize_execute_pipeline(text))
 
 # Print the output
 pretty_print(summary_text, title="Summarized by steps")

--- a/pipelex_libraries/llm_integrations/custom.toml
+++ b/pipelex_libraries/llm_integrations/custom.toml
@@ -5,11 +5,25 @@ is_gen_object_supported = false
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 0, output = 0 }
-platform_llm_id = { custom_openai = "gemma3:4b" }
+platform_llm_id = { custom_llm = "gemma3:4b" }
 
 [custom-llama-4."llama4:scout".latest]
 is_gen_object_supported = false
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 0, output = 0 }
-platform_llm_id = { custom_openai = "llama4:scout" }
+platform_llm_id = { custom_llm = "llama4:scout" }
+
+["custom-mistral-small3.1"."mistral-small3.1".latest]
+is_gen_object_supported = false
+is_vision_supported = true
+max_prompt_images = 3000
+cost_per_million_tokens_usd = { input = 0, output = 0 }
+platform_llm_id = { custom_llm = "mistral-small3.1:24b" }
+
+["custom-qwen3"."qwen3:8b".latest]
+is_gen_object_supported = false
+is_vision_supported = false
+cost_per_million_tokens_usd = { input = 0, output = 0 }
+platform_llm_id = { custom_llm = "qwen3:8b" }
+# TODO: support <think> tokens

--- a/pipelex_libraries/llm_integrations/vertexai.toml
+++ b/pipelex_libraries/llm_integrations/vertexai.toml
@@ -5,39 +5,39 @@ is_gen_object_supported = true
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 0.075, output = 0.3 }
-platform_llm_id = { vertexai_openai = "google/gemini-1.5-flash" }
+platform_llm_id = { vertexai = "google/gemini-1.5-flash" }
 
 [gemini."gemini-1.5-pro".latest]
 is_gen_object_supported = true
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 1.25, output = 5.0 }
-platform_llm_id = { vertexai_openai = "google/gemini-1.5-pro" }
+platform_llm_id = { vertexai = "google/gemini-1.5-pro" }
 
 [gemini."gemini-2.0-flash".latest]
 is_gen_object_supported = true
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 0.1, output = 0.4 }
-platform_llm_id = { vertexai_openai = "google/gemini-2.0-flash" }
+platform_llm_id = { vertexai = "google/gemini-2.0-flash" }
 
 [gemini."gemini-2.5-pro".latest]
 is_gen_object_supported = true
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 0.0, output = 0.0 }
-platform_llm_id = { vertexai_openai = "google/gemini-2.5-pro-preview-05-06" }
+platform_llm_id = { vertexai = "google/gemini-2.5-pro-preview-05-06" }
 
 [gemini."gemini-2.5-flash"."2025-04-17"]
 is_gen_object_supported = true
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 0.15, output = 0.6 }
-platform_llm_id = { vertexai_openai = "google/gemini-2.5-flash-preview-04-17" }
+platform_llm_id = { vertexai = "google/gemini-2.5-flash-preview-04-17" }
 
 [gemini."gemini-2.5-flash".latest]
 is_gen_object_supported = true
 is_vision_supported = true
 max_prompt_images = 3000
 cost_per_million_tokens_usd = { input = 0.15, output = 0.6 }
-platform_llm_id = { vertexai_openai = "google/gemini-2.5-flash-preview-05-20" }
+platform_llm_id = { vertexai = "google/gemini-2.5-flash-preview-05-20" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ dependencies = [
     "pipelex[mistralai,anthropic,google,bedrock,fal]==0.2.11",
 ]
 
+[tool.uv.sources]
+pipelex = { path = "../pipelex", editable = true }
+
 [tool.setuptools]
 packages = ["core", "community", "utils"]
 
@@ -33,6 +36,7 @@ dev = [
     "pytest>=8.3.3",
     "pytest-sugar>=1.0.0",
     "pytest_asyncio>=0.24.0",
+    "pytest-xdist>= 3.6.1",
     "ruff>=0.6.8",
     "types-aioboto3[bedrock,bedrock-runtime]>=13.4.0",
     "types-aiofiles>=24.1.0.20240626",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,6 @@ dependencies = [
     "pipelex[mistralai,anthropic,google,bedrock,fal] @ git+https://github.com/Pipelex/pipelex.git@dev",
 ]
 
-[tool.uv.sources]
-pipelex = { path = "../pipelex", editable = true }
-
 [tool.setuptools]
 packages = ["core", "community", "utils"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 
 dependencies = [
     "beautifulsoup4==4.13.4",
-    "pipelex[mistralai,anthropic,google,bedrock,fal]==0.2.11",
+    "pipelex[mistralai,anthropic,google,bedrock,fal] @ git+https://github.com/Pipelex/pipelex.git@dev",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -454,6 +454,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524, upload-time = "2024-04-08T09:04:19.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612, upload-time = "2024-04-08T09:04:17.414Z" },
+]
+
+[[package]]
 name = "fal-client"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1296,7 +1305,7 @@ wheels = [
 [[package]]
 name = "pipelex"
 version = "0.2.11"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../pipelex" }
 dependencies = [
     { name = "aiofiles" },
     { name = "filetype" },
@@ -1322,10 +1331,6 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "yattag" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/f7/34231855ecd0bda1d3357e62e4edd089491d077b635390d03904f6c6c2ac/pipelex-0.2.11.tar.gz", hash = "sha256:82c7285433ef43d62aed2ab47b1b05ac654a9cd60a01e9147118f2246c1d9689", size = 162207, upload-time = "2025-06-02T19:25:51.79Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/17/31c1d0cdf39738c89b5d590b74bb3af6ddd8ac6a9e79bc2817cf7032c994/pipelex-0.2.11-py3-none-any.whl", hash = "sha256:dc4c73feabb30a97103d6871b304090655a4134b637c592b15789a2966d89a8b", size = 273055, upload-time = "2025-06-02T19:25:50.162Z" },
-]
 
 [package.optional-dependencies]
 anthropic = [
@@ -1344,6 +1349,60 @@ google = [
 mistralai = [
     { name = "mistralai" },
 ]
+
+[package.metadata]
+requires-dist = [
+    { name = "aioboto3", marker = "extra == 'bedrock'", specifier = ">=13.4.0" },
+    { name = "aiofiles", specifier = "<24.0" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.49.0" },
+    { name = "backports-strenum", marker = "python_full_version < '3.11' and extra == 'compat'", specifier = ">=1.3.0" },
+    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.34.131" },
+    { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
+    { name = "fal-client", marker = "extra == 'fal'", specifier = ">=0.4.1" },
+    { name = "filetype", specifier = ">=1.2.0" },
+    { name = "google-auth-oauthlib", marker = "extra == 'google'", specifier = ">=1.2.1" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "instructor", specifier = ">=1.8.3" },
+    { name = "jinja2", specifier = ">=3.1.4" },
+    { name = "json2html", specifier = ">=1.3.0" },
+    { name = "kajson", specifier = ">=0.1.5" },
+    { name = "markdown", specifier = ">=3.6" },
+    { name = "mistralai", marker = "extra == 'mistralai'", specifier = "==1.5.2" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
+    { name = "networkx", specifier = ">=3.4.2" },
+    { name = "openai", specifier = ">=1.60.1" },
+    { name = "openpyxl", specifier = ">=3.1.5" },
+    { name = "pandas", specifier = ">=2.2.3" },
+    { name = "pandas-stubs", marker = "extra == 'dev'", specifier = ">=2.2.3.241126" },
+    { name = "pillow", specifier = ">=11.2.1" },
+    { name = "pydantic", specifier = "==2.10.6" },
+    { name = "pypdfium2", specifier = ">=4.30.1" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.398" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },
+    { name = "pytest-sugar", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.1" },
+    { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "rich", specifier = ">=13.8.1" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.8" },
+    { name = "shortuuid", specifier = ">=1.0.13" },
+    { name = "toml", specifier = ">=0.10.2" },
+    { name = "typer", specifier = ">=0.16.0" },
+    { name = "types-aioboto3", extras = ["bedrock", "bedrock-runtime"], marker = "extra == 'dev'", specifier = ">=13.4.0" },
+    { name = "types-aiofiles", marker = "extra == 'dev'", specifier = ">=24.1.0.20240626" },
+    { name = "types-beautifulsoup4", marker = "extra == 'dev'", specifier = ">=4.12.0.20240907" },
+    { name = "types-markdown", marker = "extra == 'dev'", specifier = ">=3.6.0.20240316" },
+    { name = "types-networkx", marker = "extra == 'dev'", specifier = ">=3.3.0.20241020" },
+    { name = "types-openpyxl", marker = "extra == 'dev'", specifier = ">=3.1.5.20250306" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20250326" },
+    { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.0.2024091" },
+    { name = "types-toml", marker = "extra == 'dev'", specifier = ">=0.10.8.20240310" },
+    { name = "typing-extensions", specifier = ">=4.13.2" },
+    { name = "yattag", specifier = ">=1.15.2" },
+]
+provides-extras = ["anthropic", "bedrock", "fal", "google", "mistralai", "compat", "dev"]
 
 [[package]]
 name = "pipelex-cookbook"
@@ -1365,6 +1424,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-sugar" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "types-aioboto3", extra = ["bedrock", "bedrock-runtime"] },
     { name = "types-aiofiles" },
@@ -1383,11 +1443,12 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = "==4.13.4" },
     { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "bedrock", "fal"], specifier = "==0.2.11" },
+    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "bedrock", "fal"], editable = "../pipelex" },
     { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.398" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-sugar", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.8" },
     { name = "types-aioboto3", extras = ["bedrock", "bedrock-runtime"], marker = "extra == 'dev'", specifier = ">=13.4.0" },
     { name = "types-aiofiles", marker = "extra == 'dev'", specifier = ">=24.1.0.20240626" },
@@ -1692,6 +1753,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/ac/5754f5edd6d508bc6493bc37d74b928f102a5fff82d9a80347e180998f08/pytest-sugar-1.0.0.tar.gz", hash = "sha256:6422e83258f5b0c04ce7c632176c7732cab5fdb909cb39cca5c9139f81276c0a", size = 14992, upload-time = "2024-02-01T18:30:36.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/92/fb/889f1b69da2f13691de09a111c16c4766a433382d44aa0ecf221deded44a/pytest_sugar-1.0.0-py3-none-any.whl", hash = "sha256:70ebcd8fc5795dc457ff8b69d266a4e2e8a74ae0c3edc749381c64b5246c8dfd", size = 10171, upload-time = "2024-02-01T18:30:29.395Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/dc/865845cfe987b21658e871d16e0a24e871e00884c545f246dd8f6f69edda/pytest_xdist-3.7.0.tar.gz", hash = "sha256:f9248c99a7c15b7d2f90715df93610353a485827bc06eefb6566d23f6400f126", size = 87550, upload-time = "2025-05-26T21:18:20.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/b2/0e802fde6f1c5b2f7ae7e9ad42b83fd4ecebac18a8a8c2f2f14e39dce6e1/pytest_xdist-3.7.0-py3-none-any.whl", hash = "sha256:7d3fbd255998265052435eb9daa4e99b62e6fb9cfb6efd1f858d4d8c0c7f0ca0", size = 46142, upload-time = "2025-05-26T21:18:18.759Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1305,7 +1305,7 @@ wheels = [
 [[package]]
 name = "pipelex"
 version = "0.2.11"
-source = { editable = "../pipelex" }
+source = { git = "https://github.com/Pipelex/pipelex.git?rev=dev#fddda669946d05b0dcfa22b718d6020e2658b10a" }
 dependencies = [
     { name = "aiofiles" },
     { name = "filetype" },
@@ -1350,60 +1350,6 @@ mistralai = [
     { name = "mistralai" },
 ]
 
-[package.metadata]
-requires-dist = [
-    { name = "aioboto3", marker = "extra == 'bedrock'", specifier = ">=13.4.0" },
-    { name = "aiofiles", specifier = "<24.0" },
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.49.0" },
-    { name = "backports-strenum", marker = "python_full_version < '3.11' and extra == 'compat'", specifier = ">=1.3.0" },
-    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.34.131" },
-    { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
-    { name = "fal-client", marker = "extra == 'fal'", specifier = ">=0.4.1" },
-    { name = "filetype", specifier = ">=1.2.0" },
-    { name = "google-auth-oauthlib", marker = "extra == 'google'", specifier = ">=1.2.1" },
-    { name = "httpx", specifier = ">=0.27.0" },
-    { name = "instructor", specifier = ">=1.8.3" },
-    { name = "jinja2", specifier = ">=3.1.4" },
-    { name = "json2html", specifier = ">=1.3.0" },
-    { name = "kajson", specifier = ">=0.1.5" },
-    { name = "markdown", specifier = ">=3.6" },
-    { name = "mistralai", marker = "extra == 'mistralai'", specifier = "==1.5.2" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "networkx", specifier = ">=3.4.2" },
-    { name = "openai", specifier = ">=1.60.1" },
-    { name = "openpyxl", specifier = ">=3.1.5" },
-    { name = "pandas", specifier = ">=2.2.3" },
-    { name = "pandas-stubs", marker = "extra == 'dev'", specifier = ">=2.2.3.241126" },
-    { name = "pillow", specifier = ">=11.2.1" },
-    { name = "pydantic", specifier = "==2.10.6" },
-    { name = "pypdfium2", specifier = ">=4.30.1" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.398" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },
-    { name = "pytest-sugar", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.1" },
-    { name = "python-dotenv", specifier = ">=1.0.1" },
-    { name = "pyyaml", specifier = ">=6.0.2" },
-    { name = "rich", specifier = ">=13.8.1" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.8" },
-    { name = "shortuuid", specifier = ">=1.0.13" },
-    { name = "toml", specifier = ">=0.10.2" },
-    { name = "typer", specifier = ">=0.16.0" },
-    { name = "types-aioboto3", extras = ["bedrock", "bedrock-runtime"], marker = "extra == 'dev'", specifier = ">=13.4.0" },
-    { name = "types-aiofiles", marker = "extra == 'dev'", specifier = ">=24.1.0.20240626" },
-    { name = "types-beautifulsoup4", marker = "extra == 'dev'", specifier = ">=4.12.0.20240907" },
-    { name = "types-markdown", marker = "extra == 'dev'", specifier = ">=3.6.0.20240316" },
-    { name = "types-networkx", marker = "extra == 'dev'", specifier = ">=3.3.0.20241020" },
-    { name = "types-openpyxl", marker = "extra == 'dev'", specifier = ">=3.1.5.20250306" },
-    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20250326" },
-    { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.0.2024091" },
-    { name = "types-toml", marker = "extra == 'dev'", specifier = ">=0.10.8.20240310" },
-    { name = "typing-extensions", specifier = ">=4.13.2" },
-    { name = "yattag", specifier = ">=1.15.2" },
-]
-provides-extras = ["anthropic", "bedrock", "fal", "google", "mistralai", "compat", "dev"]
-
 [[package]]
 name = "pipelex-cookbook"
 version = "0.1.8"
@@ -1443,7 +1389,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = "==4.13.4" },
     { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "bedrock", "fal"], editable = "../pipelex" },
+    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "bedrock", "fal"], git = "https://github.com/Pipelex/pipelex.git?rev=dev" },
     { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.398" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },


### PR DESCRIPTION
### 📝 Description

- Use renamed Mission to Pipeline
- Makefile: avoid defaulting pytest to verbose. Setup target `make test-xdist` = Run unit tests with xdist, make it the default for shorthand `make t`. The old make t is now make tp (test-with-prints)

### 🔄 Type of Change
- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [X] 🧹 Code refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
