### PR TITLE
Release/v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.2.2] - 2025-06-26
+
+- Bump `pipelex` to `v0.4.7`: Full changelog [here](https://docs.pipelex.com/changelog/)
+- `pipeline_run_id` is now available in `PipeOutput`
+
 ## [v0.2.1] - 2025-06-20
 
 - Bump `pipelex` to `v0.4.4`

--- a/Makefile
+++ b/Makefile
@@ -353,8 +353,8 @@ li: lock install
 
 check-TODOs: env
 	$(call PRINT_TITLE,"Checking for TODOs")
-	$(VENV_RUFF) check --select=TD -v .
+	$(VENV_RUFF) check --select=TD .
 
 fix-unused-imports: env
 	$(call PRINT_TITLE,"Fixing unused imports")
-	$(VENV_RUFF) check --select=F401 --fix -v .
+	$(VENV_RUFF) check --select=F401 --fix .

--- a/examples/extract_dpe.py
+++ b/examples/extract_dpe.py
@@ -17,7 +17,7 @@ async def extract_dpe(pdf_url: str) -> Dpe:
         concept_str="PDF",
         name="pdf",
     )
-    pipe_output, _ = await execute_pipeline(
+    pipe_output = await execute_pipeline(
         pipe_code="power_extractor_dpe",
         working_memory=working_memory,
     )

--- a/examples/extract_gantt.py
+++ b/examples/extract_gantt.py
@@ -21,11 +21,10 @@ async def extract_gantt(image_url: str) -> GanttChart:
     )
 
     # Run the pipe
-    pipe_output, _ = await execute_pipeline(
+    pipe_output = await execute_pipeline(
         pipe_code="extract_gantt_by_steps",
         working_memory=working_memory,
     )
-
     # Output the result
     return pipe_output.main_stuff_as(content_type=GanttChart)
 

--- a/examples/extract_generic.py
+++ b/examples/extract_generic.py
@@ -52,7 +52,7 @@ async def extract_generic(pdf_url: str) -> TextAndImagesContent:
         concept_str="PDF",
         name="pdf",
     )
-    pipe_output, _ = await execute_pipeline(
+    pipe_output = await execute_pipeline(
         pipe_code="power_extractor",
         working_memory=working_memory,
     )

--- a/examples/extract_proof_of_purchase.py
+++ b/examples/extract_proof_of_purchase.py
@@ -17,7 +17,7 @@ async def extract_proof_of_purchase(pdf_url: str) -> ProofOfPurchase:
         concept_str="PDF",
         name="pdf",
     )
-    pipe_output, _ = await execute_pipeline(
+    pipe_output = await execute_pipeline(
         pipe_code="power_extractor_proof_of_purchase",
         working_memory=working_memory,
     )

--- a/examples/extract_table.py
+++ b/examples/extract_table.py
@@ -17,7 +17,7 @@ async def extract_table(table_screenshot: str) -> HtmlTable:
         concept_str="tables.TableScreenshot",
         name="table_screenshot",
     )
-    pipe_output, _ = await execute_pipeline(
+    pipe_output = await execute_pipeline(
         pipe_code="extract_html_table_and_review",
         working_memory=working_memory,
     )

--- a/examples/invoice_extractor.py
+++ b/examples/invoice_extractor.py
@@ -23,7 +23,7 @@ async def process_expense_report() -> ListContent[Invoice]:
         pdf_url=invoice_pdf_path,
         name="invoice_pdf",
     )
-    pipe_output, _ = await execute_pipeline(
+    pipe_output = await execute_pipeline(
         pipe_code="process_invoice",
         working_memory=working_memory,
     )

--- a/examples/simple_ocr.py
+++ b/examples/simple_ocr.py
@@ -18,7 +18,7 @@ async def simple_ocr(pdf_url: str):
         concept_str="PDF",
         name="pdf",
     )
-    pipe_output, _ = await execute_pipeline(
+    pipe_output = await execute_pipeline(
         pipe_code="extract_page_contents_from_pdf",
         working_memory=working_memory,
     )

--- a/examples/wip/retrieve_then_answer.py
+++ b/examples/wip/retrieve_then_answer.py
@@ -34,7 +34,7 @@ async def retrieve_then_answer():
     working_memory = WorkingMemoryFactory.make_from_multiple_stuffs(stuff_list=[text_stuff, question_stuff, client_instructions])
 
     # Execute the retrieve_then_answer pipeline
-    pipe_output, _ = await execute_pipeline(
+    pipe_output = await execute_pipeline(
         pipe_code="retrieve_then_answer", working_memory=working_memory, dynamic_output_concept_code="contracts.Fees"
     )
 

--- a/examples/wip/write_screenplay.py
+++ b/examples/wip/write_screenplay.py
@@ -22,7 +22,7 @@ async def generate_screenplay(pitch: str):
     working_memory = WorkingMemoryFactory.make_from_single_stuff(pitch_stuff)
 
     # Run the pipe
-    pipe_output, _ = await execute_pipeline(
+    pipe_output = await execute_pipeline(
         pipe_code="generate_screenplay",
         working_memory=working_memory,
     )

--- a/examples/wip/write_tweet.py
+++ b/examples/wip/write_tweet.py
@@ -37,7 +37,7 @@ async def optimize_tweet(draft_tweet_str: str, writing_style_str: str) -> Optimi
     )
 
     # Run the sequence pipe
-    pipe_output, _ = await execute_pipeline(
+    pipe_output = await execute_pipeline(
         pipe_code="optimize_tweet_sequence",
         working_memory=working_memory,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex-cookbook"
-version = "0.2.1"
+version = "0.2.2"
 description = "Cookbook for Pipelex, the open-source declarative language that lets you define replicable, structured, composable LLM pipelines."
 authors = [{ name = "Evotis S.A.S.", email = "evotis@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]
@@ -18,7 +18,7 @@ classifiers = [
 
 dependencies = [
     "beautifulsoup4==4.13.4",
-    "pipelex[mistralai,anthropic,google,bedrock,fal]==0.4.4",
+    "pipelex[mistralai,anthropic,google,bedrock,fal]==0.4.7",
 ]
 
 [project.optional-dependencies]

--- a/quick_start/hello_world.py
+++ b/quick_start/hello_world.py
@@ -10,7 +10,7 @@ async def hello_world():
     This function demonstrates the use of a super simple Pipelex pipeline to generate text.
     """
     # Run the pipe
-    pipe_output, _ = await execute_pipeline(
+    pipe_output = await execute_pipeline(
         pipe_code="hello_world",
     )
 

--- a/quick_start/summarize_1_structured.py
+++ b/quick_start/summarize_1_structured.py
@@ -14,7 +14,7 @@ async def summarize_with_structure(text: str) -> StructuredSummary:
     working_memory = WorkingMemoryFactory.make_from_text(text=text)
 
     # Run the pipe
-    pipe_output, _ = await execute_pipeline(
+    pipe_output = await execute_pipeline(
         pipe_code="summarize_with_structure",
         working_memory=working_memory,
     )

--- a/quick_start/summarize_2_steps.py
+++ b/quick_start/summarize_2_steps.py
@@ -12,7 +12,7 @@ async def summarize_by_steps(text: str):
     working_memory = WorkingMemoryFactory.make_from_text(text=text)
 
     # Run the pipe
-    pipe_output, _ = await execute_pipeline(
+    pipe_output = await execute_pipeline(
         pipe_code="summarize_by_steps",
         working_memory=working_memory,
     )

--- a/tests/integration/test_hello_world.py
+++ b/tests/integration/test_hello_world.py
@@ -9,7 +9,7 @@ from pipelex.pipeline.execute import execute_pipeline
 async def test_hello_world(pipe_run_mode: PipeRunMode):
     """Test that the hello_world function runs successfully."""
     # Run the pipe
-    pipe_output, _ = await execute_pipeline(
+    pipe_output = await execute_pipeline(
         pipe_code="hello_world",
         pipe_run_mode=pipe_run_mode,
     )

--- a/tests/integration/test_summarize.py
+++ b/tests/integration/test_summarize.py
@@ -26,7 +26,7 @@ class TestSummarize:
         working_memory = WorkingMemoryFactory.make_from_text(text=text)
 
         # Run the pipe
-        pipe_output, _ = await execute_pipeline(
+        pipe_output = await execute_pipeline(
             pipe_code="test_summarize_by_steps",
             working_memory=working_memory,
             pipe_run_mode=pipe_run_mode,

--- a/uv.lock
+++ b/uv.lock
@@ -868,14 +868,14 @@ wheels = [
 
 [[package]]
 name = "kajson"
-version = "0.1.6"
+version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/cf/eb2cc86fc0f56b982692d2a2401d3464e8143dfc7e6549afa0eaf3613053/kajson-0.1.6.tar.gz", hash = "sha256:163abcfe8c376adb351d4e7acdc82744e2ddcb7ae4082803284318cc4d240f06", size = 15236, upload-time = "2025-06-19T10:18:00.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/90/997c2bf6c47714e1655ac7cbb718317b815c9155634148625f93faad8520/kajson-0.2.2.tar.gz", hash = "sha256:2a7d71a772d12303b398e1d6ec35fd6213fc0d23861ed860beb201105721a498", size = 19792, upload-time = "2025-06-26T10:56:01.675Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/75/53cc71d915c4269c624f8e76f10e0aff9f1112d6b568ac1b987d1b5df4b1/kajson-0.1.6-py3-none-any.whl", hash = "sha256:93ddca59dd225a79d8ffb9b54170e98b4b6c8a1f999bcf2d5981d919e132538d", size = 21594, upload-time = "2025-06-19T10:17:58.919Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/ef/9b4a1bf8b7e9fcff9450be3ed7ce69738cf7c3ef58b057385fac73eb60a1/kajson-0.2.2-py3-none-any.whl", hash = "sha256:5b1b77dab1be2af2904f9872e24e66289adeafdf1017705e1f7e0e87a1fbe6b6", size = 25863, upload-time = "2025-06-26T10:56:00.257Z" },
 ]
 
 [[package]]
@@ -1409,8 +1409,8 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.4.4"
-source = { registry = "https://pypi.org/simple" }
+version = "0.4.7"
+source = { directory = "../pipelex" }
 dependencies = [
     { name = "aiofiles" },
     { name = "filetype" },
@@ -1438,10 +1438,6 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "yattag" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/13/acb0c72f229e60ccf633db7a4024d5b94a600305bad1a4906c7801b28d36/pipelex-0.4.4.tar.gz", hash = "sha256:0bf8e963a6c1177b698d7548e910dcc6a1ce8a2b9f14b54f25c8723c22c7f806", size = 170797, upload-time = "2025-06-20T08:52:31.824Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/6b/af22294cd78aee0849722d0d9e23468a7b7c1fe4ff3d7b84a6335ff3ff14/pipelex-0.4.4-py3-none-any.whl", hash = "sha256:006c66a88b683a6bafb69eea253ce125e5a80aaba2bb91186637592068fdb8b2", size = 283346, upload-time = "2025-06-20T08:52:29.436Z" },
-]
 
 [package.optional-dependencies]
 anthropic = [
@@ -1460,6 +1456,66 @@ google = [
 mistralai = [
     { name = "mistralai" },
 ]
+
+[package.metadata]
+requires-dist = [
+    { name = "aioboto3", marker = "extra == 'bedrock'", specifier = ">=13.4.0" },
+    { name = "aiofiles", specifier = "<24.0" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.49.0" },
+    { name = "backports-strenum", marker = "python_full_version < '3.11' and extra == 'compat'", specifier = ">=1.3.0" },
+    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.34.131" },
+    { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
+    { name = "fal-client", marker = "extra == 'fal'", specifier = ">=0.4.1" },
+    { name = "filetype", specifier = ">=1.2.0" },
+    { name = "google-auth-oauthlib", marker = "extra == 'google'", specifier = ">=1.2.1" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "instructor", specifier = ">=1.8.3" },
+    { name = "jinja2", specifier = ">=3.1.4" },
+    { name = "json2html", specifier = ">=1.3.0" },
+    { name = "kajson", specifier = "==0.2.2" },
+    { name = "markdown", specifier = ">=3.6" },
+    { name = "mistralai", marker = "extra == 'mistralai'", specifier = "==1.5.2" },
+    { name = "mkdocs", marker = "extra == 'docs'", specifier = "==1.6.1" },
+    { name = "mkdocs-glightbox", marker = "extra == 'docs'", specifier = "==0.4.0" },
+    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = "==9.6.14" },
+    { name = "mkdocs-meta-manager", marker = "extra == 'docs'", specifier = "==1.1.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
+    { name = "networkx", specifier = ">=3.4.2" },
+    { name = "openai", specifier = ">=1.60.1" },
+    { name = "openpyxl", specifier = ">=3.1.5" },
+    { name = "pandas", specifier = ">=2.2.3" },
+    { name = "pandas-stubs", marker = "extra == 'dev'", specifier = ">=2.2.3.241126" },
+    { name = "pillow", specifier = ">=11.2.1" },
+    { name = "polyfactory", specifier = ">=2.21.0" },
+    { name = "pydantic", specifier = "==2.10.6" },
+    { name = "pypdfium2", specifier = ">=4.30.1" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.398" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },
+    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14.0" },
+    { name = "pytest-sugar", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.1" },
+    { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "rich", specifier = ">=13.8.1" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.8" },
+    { name = "shortuuid", specifier = ">=1.0.13" },
+    { name = "toml", specifier = ">=0.10.2" },
+    { name = "typer", specifier = ">=0.16.0" },
+    { name = "types-aioboto3", extras = ["bedrock", "bedrock-runtime"], marker = "extra == 'dev'", specifier = ">=13.4.0" },
+    { name = "types-aiofiles", marker = "extra == 'dev'", specifier = ">=24.1.0.20240626" },
+    { name = "types-beautifulsoup4", marker = "extra == 'dev'", specifier = ">=4.12.0.20240907" },
+    { name = "types-markdown", marker = "extra == 'dev'", specifier = ">=3.6.0.20240316" },
+    { name = "types-networkx", marker = "extra == 'dev'", specifier = ">=3.3.0.20241020" },
+    { name = "types-openpyxl", marker = "extra == 'dev'", specifier = ">=3.1.5.20250306" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20250326" },
+    { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.0.2024091" },
+    { name = "types-toml", marker = "extra == 'dev'", specifier = ">=0.10.8.20240310" },
+    { name = "typing-extensions", specifier = ">=4.13.2" },
+    { name = "yattag", specifier = ">=1.15.2" },
+]
+provides-extras = ["anthropic", "bedrock", "fal", "google", "mistralai", "compat", "docs", "dev"]
 
 [[package]]
 name = "pipelex-cookbook"
@@ -1502,7 +1558,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = "==4.13.4" },
     { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "bedrock", "fal"], specifier = "==0.4.4" },
+    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "bedrock", "fal"], directory = "../pipelex" },
     { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.398" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },


### PR DESCRIPTION
## [v0.2.2] - 2025-06-26

- Bump `pipelex` to `v0.4.7`: Full changelog [here](https://docs.pipelex.com/changelog/)
- `pipeline_run_id` is now available in `PipeOutput`