### PR TITLE
Release/v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
   # Changelog
 
+## [v0.2.4] - 2025-06-30
+
+- Bump `pipelex` to `v0.4.11`
+- Avoid repetition of llm choice for structured generation in some examples
+
 ## [v0.2.3] - 2025-06-30
 
 ### Core Updates

--- a/pipelex_libraries/llm_deck/base_llm_deck.toml
+++ b/pipelex_libraries/llm_deck/base_llm_deck.toml
@@ -16,6 +16,7 @@ best-gemini = "gemini-2.5-pro"
 best-mistral = "mistral-large"
 best-grok = "grok-3"
 
+
 ####################################################################################################
 # LLM Presets
 ####################################################################################################
@@ -25,7 +26,7 @@ best-grok = "grok-3"
 ####################################################################################################
 # LLM Presets — General purpose
 
-cheap_llm_for_text = { llm_handle = "gpt-4o-mini", temperature = 0.5, max_tokens = 50 }
+cheap_llm_for_text = { llm_handle = "gpt-4o-mini", temperature = 0.5 }
 cheap_llm_for_short_text = { llm_handle = "gpt-4o-mini", temperature = 0.5, max_tokens = 50 }
 cheap_llm_for_object = { llm_handle = "gpt-4o-mini", temperature = 0.5 }
 cheap_llm_to_structure = { llm_handle = "gpt-4o-mini", temperature = 0.1 }
@@ -76,6 +77,3 @@ llm_to_extract_tables = { llm_handle = "best-claude", temperature = 0.1 }
 [llm_choice_defaults]
 for_text = "cheap_llm_for_text"
 for_object = "cheap_llm_for_object"
-for_object_direct = "cheap_llm_for_object"
-for_object_list = "cheap_llm_for_object"
-for_object_list_direct = "cheap_llm_for_object"

--- a/pipelex_libraries/llm_deck/overrides.toml
+++ b/pipelex_libraries/llm_deck/overrides.toml
@@ -7,6 +7,3 @@
 [llm_choice_overrides]
 for_text = "disabled"
 for_object = "disabled"
-for_object_direct = "disabled"
-for_object_list = "disabled"
-for_object_list_direct = "disabled"

--- a/pipelex_libraries/pipelines/examples/extract_gantt/gantt.toml
+++ b/pipelex_libraries/pipelines/examples/extract_gantt/gantt.toml
@@ -30,7 +30,6 @@ PipeLLM = "Describe the timescale of a gantt chart"
 inputs = { gantt_chart_image = "GanttChartImage" }
 output = "GanttTimescaleDescription"
 llm = "llm_to_extract_diagram"
-llm_to_structure = "llm_to_extract_diagram"
 prompt_template = """
 I am sharing an image of a Gantt chart.
 Please analyze the timescale: what is the smallest unit detailed in the time scale?
@@ -41,7 +40,6 @@ PipeLLM = "List all the tasks"
 inputs = { gantt_chart_image = "GanttChartImage" }
 output = "GanttTaskName"
 llm = "llm_to_extract_diagram"
-llm_to_structure = "llm_to_extract_diagram"
 multiple_output = true
 prompt_template = """
 I am sharing an image of a Gantt chart.

--- a/pipelex_libraries/pipelines/examples/extract_gantt/gantt.toml
+++ b/pipelex_libraries/pipelines/examples/extract_gantt/gantt.toml
@@ -31,7 +31,6 @@ inputs = { gantt_chart_image = "GanttChartImage" }
 output = "GanttTimescaleDescription"
 llm = "llm_to_extract_diagram"
 llm_to_structure = "llm_to_extract_diagram"
-llm_to_structure_direct = "llm_to_extract_diagram"
 prompt_template = """
 I am sharing an image of a Gantt chart.
 Please analyze the timescale: what is the smallest unit detailed in the time scale?
@@ -43,7 +42,6 @@ inputs = { gantt_chart_image = "GanttChartImage" }
 output = "GanttTaskName"
 llm = "llm_to_extract_diagram"
 llm_to_structure = "llm_to_extract_diagram"
-llm_to_structure_direct = "llm_to_extract_diagram"
 multiple_output = true
 prompt_template = """
 I am sharing an image of a Gantt chart.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex-cookbook"
-version = "0.2.3"
+version = "0.2.4"
 description = "Cookbook for Pipelex, the open-source declarative language that lets you define replicable, structured, composable LLM pipelines."
 authors = [{ name = "Evotis S.A.S.", email = "evotis@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,8 @@ classifiers = [
 
 dependencies = [
     "beautifulsoup4==4.13.4",
-    "pipelex[mistralai,anthropic,google,bedrock,fal]==0.4.9",
+    "pipelex[mistralai,anthropic,google,bedrock,fal]==0.4.11",
 ]
-
-[tool.uv.sources]
-pipelex = { path = "../pipelex", editable = true }
-
 
 [project.optional-dependencies]
 compat = ["backports.strenum>=1.3.0 ; python_version < '3.11'"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,10 @@ dependencies = [
     "pipelex[mistralai,anthropic,google,bedrock,fal]==0.4.9",
 ]
 
+[tool.uv.sources]
+pipelex = { path = "../pipelex", editable = true }
+
+
 [project.optional-dependencies]
 compat = ["backports.strenum>=1.3.0 ; python_version < '3.11'"]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1409,8 +1409,8 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.4.10"
-source = { editable = "../pipelex" }
+version = "0.4.11"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
     { name = "filetype" },
@@ -1438,6 +1438,10 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "yattag" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/88/d0/771aa9484788d9fae6ac22551b7804a990ca0ededbaa9e7232c6a04b3487/pipelex-0.4.11.tar.gz", hash = "sha256:87d84c6d45afd0ba8c9a1c08f525eb85e321d4d072707ec8ee865443841e12c8", size = 175422, upload-time = "2025-06-30T17:40:35.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/24/d6462026c01c2f352135d0d87cf13bf75d780152d31f37b2d784aedfa6f7/pipelex-0.4.11-py3-none-any.whl", hash = "sha256:528e969ae5a2c925d8327e6b6c32b99532c7de130c66c0cbe2920f1b2aa4932a", size = 291345, upload-time = "2025-06-30T17:40:33.484Z" },
+]
 
 [package.optional-dependencies]
 anthropic = [
@@ -1456,66 +1460,6 @@ google = [
 mistralai = [
     { name = "mistralai" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "aioboto3", marker = "extra == 'bedrock'", specifier = ">=13.4.0" },
-    { name = "aiofiles", specifier = "<24.0" },
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.49.0" },
-    { name = "backports-strenum", marker = "python_full_version < '3.11' and extra == 'compat'", specifier = ">=1.3.0" },
-    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.34.131" },
-    { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
-    { name = "fal-client", marker = "extra == 'fal'", specifier = ">=0.4.1" },
-    { name = "filetype", specifier = ">=1.2.0" },
-    { name = "google-auth-oauthlib", marker = "extra == 'google'", specifier = ">=1.2.1" },
-    { name = "httpx", specifier = ">=0.27.0" },
-    { name = "instructor", specifier = ">=1.8.3" },
-    { name = "jinja2", specifier = ">=3.1.4" },
-    { name = "json2html", specifier = ">=1.3.0" },
-    { name = "kajson", specifier = "==0.2.3" },
-    { name = "markdown", specifier = ">=3.6" },
-    { name = "mistralai", marker = "extra == 'mistralai'", specifier = "==1.5.2" },
-    { name = "mkdocs", marker = "extra == 'docs'", specifier = "==1.6.1" },
-    { name = "mkdocs-glightbox", marker = "extra == 'docs'", specifier = "==0.4.0" },
-    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = "==9.6.14" },
-    { name = "mkdocs-meta-manager", marker = "extra == 'docs'", specifier = "==1.1.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "networkx", specifier = ">=3.4.2" },
-    { name = "openai", specifier = ">=1.60.1" },
-    { name = "openpyxl", specifier = ">=3.1.5" },
-    { name = "pandas", specifier = ">=2.2.3" },
-    { name = "pandas-stubs", marker = "extra == 'dev'", specifier = ">=2.2.3.241126" },
-    { name = "pillow", specifier = ">=11.2.1" },
-    { name = "polyfactory", specifier = ">=2.21.0" },
-    { name = "pydantic", specifier = "==2.10.6" },
-    { name = "pypdfium2", specifier = ">=4.30.1" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.398" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },
-    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14.0" },
-    { name = "pytest-sugar", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.1" },
-    { name = "python-dotenv", specifier = ">=1.0.1" },
-    { name = "pyyaml", specifier = ">=6.0.2" },
-    { name = "rich", specifier = ">=13.8.1" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.8" },
-    { name = "shortuuid", specifier = ">=1.0.13" },
-    { name = "toml", specifier = ">=0.10.2" },
-    { name = "typer", specifier = ">=0.16.0" },
-    { name = "types-aioboto3", extras = ["bedrock", "bedrock-runtime"], marker = "extra == 'dev'", specifier = ">=13.4.0" },
-    { name = "types-aiofiles", marker = "extra == 'dev'", specifier = ">=24.1.0.20240626" },
-    { name = "types-beautifulsoup4", marker = "extra == 'dev'", specifier = ">=4.12.0.20240907" },
-    { name = "types-markdown", marker = "extra == 'dev'", specifier = ">=3.6.0.20240316" },
-    { name = "types-networkx", marker = "extra == 'dev'", specifier = ">=3.3.0.20241020" },
-    { name = "types-openpyxl", marker = "extra == 'dev'", specifier = ">=3.1.5.20250306" },
-    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20250326" },
-    { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.0.2024091" },
-    { name = "types-toml", marker = "extra == 'dev'", specifier = ">=0.10.8.20240310" },
-    { name = "typing-extensions", specifier = ">=4.13.2" },
-    { name = "yattag", specifier = ">=1.15.2" },
-]
-provides-extras = ["anthropic", "bedrock", "fal", "google", "mistralai", "compat", "docs", "dev"]
 
 [[package]]
 name = "pipelex-cookbook"
@@ -1558,7 +1502,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = "==4.13.4" },
     { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "bedrock", "fal"], editable = "../pipelex" },
+    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "bedrock", "fal"], specifier = "==0.4.11" },
     { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.398" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1409,8 +1409,8 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.4.9"
-source = { registry = "https://pypi.org/simple" }
+version = "0.4.10"
+source = { editable = "../pipelex" }
 dependencies = [
     { name = "aiofiles" },
     { name = "filetype" },
@@ -1438,10 +1438,6 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "yattag" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/71/3ce99b728c71d4f4ee91474aee6234e89b7eee5a6a6e0c2d1a441053f512/pipelex-0.4.9.tar.gz", hash = "sha256:9987fa08de12096eca14ea958fadfc38dc8b6e8579bee643db5605c6fde87e4a", size = 175840, upload-time = "2025-06-30T09:15:33.166Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/f9/960a22c9a6822b699c4ea1868ba5bfd2dd6bbd5c6e881fe7838eb14a5b3c/pipelex-0.4.9-py3-none-any.whl", hash = "sha256:7bd5a5cd5cbaaa1a5932a98672ba4df31cc569c2ddae1fdc83345b4c3e58570e", size = 291663, upload-time = "2025-06-30T09:15:31.444Z" },
-]
 
 [package.optional-dependencies]
 anthropic = [
@@ -1460,6 +1456,66 @@ google = [
 mistralai = [
     { name = "mistralai" },
 ]
+
+[package.metadata]
+requires-dist = [
+    { name = "aioboto3", marker = "extra == 'bedrock'", specifier = ">=13.4.0" },
+    { name = "aiofiles", specifier = "<24.0" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.49.0" },
+    { name = "backports-strenum", marker = "python_full_version < '3.11' and extra == 'compat'", specifier = ">=1.3.0" },
+    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.34.131" },
+    { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
+    { name = "fal-client", marker = "extra == 'fal'", specifier = ">=0.4.1" },
+    { name = "filetype", specifier = ">=1.2.0" },
+    { name = "google-auth-oauthlib", marker = "extra == 'google'", specifier = ">=1.2.1" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "instructor", specifier = ">=1.8.3" },
+    { name = "jinja2", specifier = ">=3.1.4" },
+    { name = "json2html", specifier = ">=1.3.0" },
+    { name = "kajson", specifier = "==0.2.3" },
+    { name = "markdown", specifier = ">=3.6" },
+    { name = "mistralai", marker = "extra == 'mistralai'", specifier = "==1.5.2" },
+    { name = "mkdocs", marker = "extra == 'docs'", specifier = "==1.6.1" },
+    { name = "mkdocs-glightbox", marker = "extra == 'docs'", specifier = "==0.4.0" },
+    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = "==9.6.14" },
+    { name = "mkdocs-meta-manager", marker = "extra == 'docs'", specifier = "==1.1.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
+    { name = "networkx", specifier = ">=3.4.2" },
+    { name = "openai", specifier = ">=1.60.1" },
+    { name = "openpyxl", specifier = ">=3.1.5" },
+    { name = "pandas", specifier = ">=2.2.3" },
+    { name = "pandas-stubs", marker = "extra == 'dev'", specifier = ">=2.2.3.241126" },
+    { name = "pillow", specifier = ">=11.2.1" },
+    { name = "polyfactory", specifier = ">=2.21.0" },
+    { name = "pydantic", specifier = "==2.10.6" },
+    { name = "pypdfium2", specifier = ">=4.30.1" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.398" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },
+    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14.0" },
+    { name = "pytest-sugar", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.1" },
+    { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "rich", specifier = ">=13.8.1" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.8" },
+    { name = "shortuuid", specifier = ">=1.0.13" },
+    { name = "toml", specifier = ">=0.10.2" },
+    { name = "typer", specifier = ">=0.16.0" },
+    { name = "types-aioboto3", extras = ["bedrock", "bedrock-runtime"], marker = "extra == 'dev'", specifier = ">=13.4.0" },
+    { name = "types-aiofiles", marker = "extra == 'dev'", specifier = ">=24.1.0.20240626" },
+    { name = "types-beautifulsoup4", marker = "extra == 'dev'", specifier = ">=4.12.0.20240907" },
+    { name = "types-markdown", marker = "extra == 'dev'", specifier = ">=3.6.0.20240316" },
+    { name = "types-networkx", marker = "extra == 'dev'", specifier = ">=3.3.0.20241020" },
+    { name = "types-openpyxl", marker = "extra == 'dev'", specifier = ">=3.1.5.20250306" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20250326" },
+    { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.0.2024091" },
+    { name = "types-toml", marker = "extra == 'dev'", specifier = ">=0.10.8.20240310" },
+    { name = "typing-extensions", specifier = ">=4.13.2" },
+    { name = "yattag", specifier = ">=1.15.2" },
+]
+provides-extras = ["anthropic", "bedrock", "fal", "google", "mistralai", "compat", "docs", "dev"]
 
 [[package]]
 name = "pipelex-cookbook"
@@ -1502,7 +1558,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = "==4.13.4" },
     { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "bedrock", "fal"], specifier = "==0.4.9" },
+    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "bedrock", "fal"], editable = "../pipelex" },
     { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.398" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },


### PR DESCRIPTION

- Bump `pipelex` to `v0.4.11`
- Avoid repetition of llm choice for structured generation in some examples