### PR TITLE
Release/v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.4.2] - 2025-09-03
+
+- README link to [Pipelex IDE extension](https://open-vsx.org/extension/Pipelex/pipelex)
+
 ## [v0.4.1] - 2025-09-02
 
 - Update cursor rules with `PLX` extension naming

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ cp .env.example .env
 
 Enter your API keys into your `.env` file. The `OPENAI_API_KEY` is enough to get you started, but some pipelines require models from other providers.
 
+### IDE extension
+
+We **highly** recommend installing our own extension for PLX files into your IDE of choice. You can find it in the [Open VSX Registry](https://open-vsx.org/extension/Pipelex/pipelex). It's coming soon to VS Code marketplace too and if you are using Cursor, Windsurf or another VS Code fork, you can search for it directly in your extensions tab.
+
 ### Run Hello World
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex-cookbook"
-version = "0.4.1"
+version = "0.4.2"
 description = "Cookbook for Pipelex, the open-source declarative language that lets you define replicable, structured, composable LLM pipelines."
 authors = [{ name = "Evotis S.A.S.", email = "evotis@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]


### PR DESCRIPTION

## [v0.4.2] - 2025-09-03

- README link to [Pipelex IDE extension](https://open-vsx.org/extension/Pipelex/pipelex)