### PR TITLE
Fix running CI without inference and so without service agreement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,12 +209,12 @@ cleanall: cleanderived cleanenv
 codex-tests: env
 	$(call PRINT_TITLE,"Unit testing for Codex")
 	@echo "• Running unit tests for Codex (excluding inference and codex_disabled)"
-	$(VENV_PYTEST) --exitfirst --quiet -m "not inference and not codex_disabled" || [ $$? = 5 ]
+	$(VENV_PYTEST) --disable-inference --exitfirst --quiet -m "not inference and not codex_disabled" || [ $$? = 5 ]
 
 gha-tests: env
 	$(call PRINT_TITLE,"Unit testing for github actions")
 	@echo "• Running unit tests for github actions (excluding inference and gha_disabled)"
-	$(VENV_PYTEST) --exitfirst --quiet -m "not inference and not gha_disabled" || [ $$? = 5 ]
+	$(VENV_PYTEST) --disable-inference --exitfirst --quiet -m "not inference and not gha_disabled" || [ $$? = 5 ]
 
 run-all-tests: env
 	$(call PRINT_TITLE,"Running all unit tests")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,17 +1,21 @@
 import pipelex.config
 import pipelex.pipelex
 import pytest
+from pipelex.test_extras.shared_pytest_plugins import is_inference_disabled_in_pipelex
 from rich import print
 from rich.console import Console
 from rich.traceback import Traceback
 
 
 @pytest.fixture(scope="module", autouse=True)
-def reset_pipelex_config_fixture():
+def reset_pipelex_config_fixture(request: pytest.FixtureRequest):
     # Code to run before each test
     print("\n[magenta]pipelex setup[/magenta]")
     try:
-        pipelex_instance = pipelex.pipelex.Pipelex.make(library_dirs=["examples", "tests/test_pipelines"])
+        pipelex_instance = pipelex.pipelex.Pipelex.make(
+            library_dirs=["examples", "tests/test_pipelines"],
+            disable_inference=is_inference_disabled_in_pipelex(request),
+        )
     except Exception as exc:
         Console().print(Traceback())
         pytest.exit(f"Critical Pipelex setup error: {exc}")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,17 +1,20 @@
 import pipelex.config
 import pipelex.pipelex
 import pytest
+from pipelex.test_extras.shared_pytest_plugins import is_inference_disabled_in_pipelex
 from rich import print
 from rich.console import Console
 from rich.traceback import Traceback
 
 
 @pytest.fixture(scope="module", autouse=True)
-def reset_pipelex_config_fixture():
+def reset_pipelex_config_fixture(request: pytest.FixtureRequest):
     # Code to run before each test
     print("\n[magenta]pipelex setup[/magenta]")
     try:
-        pipelex_instance = pipelex.pipelex.Pipelex.make()
+        pipelex_instance = pipelex.pipelex.Pipelex.make(
+            disable_inference=is_inference_disabled_in_pipelex(request),
+        )
     except Exception as exc:
         Console().print(Traceback())
         pytest.exit(f"Critical Pipelex setup error: {exc}")

--- a/uv.lock
+++ b/uv.lock
@@ -2367,7 +2367,7 @@ wheels = [
 [[package]]
 name = "pipelex"
 version = "0.17.3"
-source = { git = "https://github.com/Pipelex/pipelex.git?branch=feature%2FChicago#548a12ee766bb1fe654827a234f8d49567cc05c4" }
+source = { git = "https://github.com/Pipelex/pipelex.git?branch=feature%2FChicago#6c6301aeec180ffcf9ae2cc3cfa1af354004122d" }
 dependencies = [
     { name = "aiofiles" },
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
- Fix running CI without inference and so without service agreement

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures CI/test runs execute with inference disabled by default.
> 
> - Add `--disable-inference` to `codex-tests` and `gha-tests` in `Makefile`
> - Update `tests/unit/conftest.py` and `tests/integration/conftest.py` fixtures to pass `disable_inference` via `is_inference_disabled_in_pipelex(request)`
> - Bump `pipelex` git ref in `uv.lock`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a4757ab76d77cac3bc86c8607e6f5e12d529666. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->