### PR TITLE
Use-generic-pre-release-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <br/>
   <h2 align="center">Pipelex Cookbook 📚</h2>
   <!-- PRERELEASE_LINK -->
-  <p align="center">Examples, recipes, and best-practice pipelines for the <strong><a href="https://github.com/Pipelex/pipelex/tree/pre-release/v0.18.0b1">Pipelex</a></strong> AI workflow framework.<br/>
+  <p align="center">Examples, recipes, and best-practice pipelines for the <strong><a href="https://go.pipelex.com/pre-release">Pipelex</a></strong> AI workflow framework.<br/>
 Learn by doing with production-ready examples.</p>
 
   <div>
@@ -31,7 +31,7 @@ Learn by doing with production-ready examples.</p>
     <a href="https://www.youtube.com/@PipelexAI"><img src="https://img.shields.io/badge/YouTube-FF0000?logo=youtube&logoColor=white" alt="YouTube"></a>
     <a href="https://pipelex.com"><img src="https://img.shields.io/badge/Homepage-03bb95?logo=google-chrome&logoColor=white&style=flat" alt="Website"></a>
 <!-- PRERELEASE_LINK -->
-    <a href="https://github.com/Pipelex/pipelex/tree/pre-release/v0.18.0b1"><img src="https://img.shields.io/badge/Main_Repo-5a0dad?logo=github&logoColor=white&style=flat" alt="Main Repository"></a>
+    <a href="https://go.pipelex.com/pre-release"><img src="https://img.shields.io/badge/Main_Repo-5a0dad?logo=github&logoColor=white&style=flat" alt="Main Repository"></a>
     <a href="https://docs.pipelex.com/"><img src="https://img.shields.io/badge/Docs-03bb95?logo=read-the-docs&logoColor=white&style=flat" alt="Documentation"></a>
     <br/> 
     <br/>
@@ -423,8 +423,7 @@ Each example includes:
 
 We ❤️ contributions! Before opening a pull request, please:
 
-<!-- PRERELEASE_LINK -->
-1. **Read [`CONTRIBUTING.md`](CONTRIBUTING.md)** and the [main repository's contributing guide](https://github.com/Pipelex/pipelex/blob/pre-release/v0.18.0b1/CONTRIBUTING.md).
+1. **Read [`CONTRIBUTING.md`](CONTRIBUTING.md)** and the [main repository's contributing guide](https://github.com/Pipelex/pipelex/blob/main/CONTRIBUTING.md).
 2. Add your file under **`examples/wip/<your-folder>`**; feel free to group related examples by topic.
 3. Include a short **README or docstring** at the top describing purpose, inputs, and expected outputs.
 4. Verify the pipeline runs locally with a free/open LLM preset when possible, to lower the entry barrier for reviewers.

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -3,7 +3,7 @@
 Welcome to the Pipelex tutorials! Learn how to build AI pipelines step by step.
 
 
-> **Note**: The easiest way to create pipelines is with the <!-- PRERELEASE_LINK -->[Pipe Builder](https://docs.pipelex.com/0.18.0b1/home/9-tools/pipe-builder/). These tutorials teach you the fundamentals by writing pipelines manually.
+> **Note**: The easiest way to create pipelines is with the <!-- PRERELEASE_LINK -->[Pipe Builder](https://docs.pipelex.com/pre-release/home/9-tools/pipe-builder/). These tutorials teach you the fundamentals by writing pipelines manually.
 
 ## Tutorials
 

--- a/tutorial/medium/README.md
+++ b/tutorial/medium/README.md
@@ -8,7 +8,7 @@ Take your Pipelex skills to the next level.
 
 Control which LLM to use and how it behaves.
 
-**To change default models and presets**, edit `.pipelex/inference/deck/base_deck.toml`. See the [full list of available models](https://docs.pipelex.com/0.18.0b1/home/5-setup/gateway-models/) and the <!-- PRERELEASE_LINK -->[Inference Backend Configuration](https://docs.pipelex.com/0.18.0b1/home/7-configuration/config-technical/inference-backend-config/) documentation for details.
+**To change default models and presets**, edit `.pipelex/inference/deck/base_deck.toml`. See the [full list of available models](https://docs.pipelex.com/pre-release/home/5-setup/gateway-models/) and the <!-- PRERELEASE_LINK -->[Inference Backend Configuration](https://docs.pipelex.com/pre-release/home/7-configuration/config-technical/inference-backend-config/) documentation for details.
 
 **File: `1_model_config.plx`**
 


### PR DESCRIPTION
- Use-generic-pre-release-links

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Docs cleanup: use generic pre-release links**
> 
> - Updated `README.md` to point `Pipelex` and `Main_Repo` badges/links to `https://go.pipelex.com/pre-release` instead of version-specific URLs
> - Switched tutorial links in `tutorial/README.md` and `tutorial/medium/README.md` from `0.18.0b1` paths to `pre-release` docs paths
> - Updated contributing guide link in `README.md` to the `main` branch
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc85eba23465e1644232de25a2c0faf2e093907f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->