### PR TITLE
Feature/tweaks

### DIFF
--- a/.pipelex/inference/deck/3_extract_deck.toml
+++ b/.pipelex/inference/deck/3_extract_deck.toml
@@ -19,24 +19,24 @@
 ####################################################################################################
 
 [extract]
-choice_default = "$extract-all-from-document"
+choice_default = "@default-extract-document"
 
 ####################################################################################################
 # Aliases
 ####################################################################################################
 
 [extract.aliases]
-default-extract-document = "azure-document-intelligence"
-default-extract-text-from-pdf = "pypdfium2-extract-pdf"
-default-software-extract-no-inference = "pypdfium2-extract-pdf"
+default-premium = "azure-document-intelligence"
+default-extract-document = "mistral-document-ai-2505"
+default-extract-image = "mistral-document-ai-2505"
+default-text-from-pdf = "pypdfium2-extract-pdf"
+default-no-inference = "pypdfium2-extract-pdf"
 
 ####################################################################################################
 # Extract Presets
 ####################################################################################################
 
 [extract.presets]
-extract-all-from-document = { model = "@default-extract-document", max_nb_images = 100, image_min_size = 50 }
-extract-text-from-pdf = { model = "@default-extract-text-from-pdf", max_nb_images = 100, image_min_size = 50 }
 
 # Testing
-extract-testing = { model = "@default-software-extract-no-inference", max_nb_images = 100, image_min_size = 50 }
+extract-testing = { model = "@default-extract-document", max_nb_images = 5, image_min_size = 50 }

--- a/examples/c_advanced/using_inference_plugins/hello_plugin.plx
+++ b/examples/c_advanced/using_inference_plugins/hello_plugin.plx
@@ -2,6 +2,7 @@
 
 domain = "hello_plugin"
 description = "Using an LLM Plugin"
+main_pipe = "hello_plugin"
 
 [pipe]
 [pipe.hello_plugin]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-pipelex = { git = "https://github.com/Pipelex/pipelex.git", rev = "feature/Chicago" }
+# pipelex = { git = "https://github.com/Pipelex/pipelex.git", rev = "feature/Chicago" }
+# pipelex = { git = "https://github.com/Pipelex/pipelex.git", rev = "92c184c56a78832e125d973c2847b75969453be4" }
+pipelex = { git = "https://github.com/Pipelex/pipelex.git", rev = "e0142c4407eef7d49b03d2a0e88c7d877c60123b" }
 
 [project.optional-dependencies]
 compat = ["backports.strenum>=1.3.0 ; python_version < '3.11'"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-# pipelex = { git = "https://github.com/Pipelex/pipelex.git", rev = "feature/Chicago" }
-# pipelex = { git = "https://github.com/Pipelex/pipelex.git", rev = "92c184c56a78832e125d973c2847b75969453be4" }
-pipelex = { git = "https://github.com/Pipelex/pipelex.git", rev = "e0142c4407eef7d49b03d2a0e88c7d877c60123b" }
+pipelex = { git = "https://github.com/Pipelex/pipelex.git", rev = "feature/Chicago" }
 
 [project.optional-dependencies]
 compat = ["backports.strenum>=1.3.0 ; python_version < '3.11'"]

--- a/tests/e2e/test_wip.py
+++ b/tests/e2e/test_wip.py
@@ -1,6 +1,9 @@
+import runpy
 import subprocess
 
 import pytest
+
+from examples.wip.discord_newsletter import run_discord_newsletter
 
 
 @pytest.mark.inference
@@ -30,10 +33,5 @@ class TestWip:
         )
         assert result.returncode == 0, f"Command failed: {result.stderr}"
 
-    def test_discord_newsletter(self, pipelex_cmd: str):
-        result = subprocess.run(
-            [pipelex_cmd, "run", "examples/wip/discord_newsletter/bundle.plx", "-i", "examples/wip/discord_newsletter/inputs.json"],
-            capture_output=True,
-            text=True,
-        )
-        assert result.returncode == 0, f"Command failed: {result.stderr}"
+    def test_discord_newsletter(self):
+        runpy.run_path(run_discord_newsletter.__file__, run_name="__main__")

--- a/uv.lock
+++ b/uv.lock
@@ -2942,7 +2942,7 @@ wheels = [
 [[package]]
 name = "pipelex"
 version = "0.18.0b2"
-source = { git = "https://github.com/Pipelex/pipelex.git?rev=feature%2FChicago#1876264aef90cc6705dfe1db92027ba749933525" }
+source = { git = "https://github.com/Pipelex/pipelex.git?rev=e0142c4407eef7d49b03d2a0e88c7d877c60123b#e0142c4407eef7d49b03d2a0e88c7d877c60123b" }
 dependencies = [
     { name = "aiofiles" },
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },
@@ -3040,7 +3040,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = "==4.13.4" },
     { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "google-genai", "bedrock", "fal", "docling"], git = "https://github.com/Pipelex/pipelex.git?rev=feature%2FChicago" },
+    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "google-genai", "bedrock", "fal", "docling"], git = "https://github.com/Pipelex/pipelex.git?rev=e0142c4407eef7d49b03d2a0e88c7d877c60123b" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.405" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -2942,7 +2942,7 @@ wheels = [
 [[package]]
 name = "pipelex"
 version = "0.18.0b2"
-source = { git = "https://github.com/Pipelex/pipelex.git?rev=e0142c4407eef7d49b03d2a0e88c7d877c60123b#e0142c4407eef7d49b03d2a0e88c7d877c60123b" }
+source = { git = "https://github.com/Pipelex/pipelex.git?rev=feature%2FChicago#d7cd813f1422d37a35cfa538ab2228ce30fb8e0b" }
 dependencies = [
     { name = "aiofiles" },
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },
@@ -3040,7 +3040,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = "==4.13.4" },
     { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "google-genai", "bedrock", "fal", "docling"], git = "https://github.com/Pipelex/pipelex.git?rev=e0142c4407eef7d49b03d2a0e88c7d877c60123b" },
+    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "google-genai", "bedrock", "fal", "docling"], git = "https://github.com/Pipelex/pipelex.git?rev=feature%2FChicago" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.405" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the default document extraction model/presets and alters how an e2e test executes a newsletter example, which could impact inference behavior and CI stability.
> 
> **Overview**
> Updates the document-extraction deck to use `@default-extract-document` as the default choice and retargets aliases so extraction defaults to `mistral-document-ai-2505` (while keeping `azure-document-intelligence` as `default-premium`). Also trims the `extract-testing` preset to process fewer images.
> 
> Tweaks examples/tests: sets `main_pipe` in the inference plugin example, and changes the WIP Discord newsletter e2e test to execute the example module via `runpy` instead of invoking `pipelex run`. Updates `uv.lock` to a newer `pipelex` git revision.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b5617077d08a012ffef4e0c4a06ff37e29f6ab6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->