### PR TITLE
Release/v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.11.1] - 2026-03-01
+
+- Bump `pipelex` to `0.18.5`. See `Pipelex` changelog [here](https://docs.pipelex.com/changelog/)
+
 ## [v0.11.0] - 2026-02-27
 
 - Bump `pipelex` to `0.18.3`. See `Pipelex` changelog [here](https://docs.pipelex.com/changelog/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex-cookbook"
-version = "0.11.0"
+version = "0.11.1"
 description = "Cookbook for Pipelex, the open standard for repeatable AI methods. Write business logic, not API calls."
 authors = [{ name = "Evotis S.A.S.", email = "evotis@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]
@@ -19,7 +19,7 @@ classifiers = [
 
 dependencies = [
   "beautifulsoup4==4.13.4",
-  "pipelex[mistralai,anthropic,google,google-genai,bedrock,fal,docling]==0.18.3",
+  "pipelex[mistralai,anthropic,google,google-genai,bedrock,fal,docling]==0.18.5",
   "weasyprint==68.0",
 ]
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,7 @@
 import pipelex.config
 import pipelex.pipelex
 import pytest
-from pipelex.test_extras.shared_pytest_plugins import is_inference_disabled_in_pipelex
+from pipelex.test_extras.shared_pytest_plugins import needs_inference_in_pipelex
 from rich import print
 from rich.console import Console
 from rich.traceback import Traceback
@@ -14,7 +14,7 @@ def reset_pipelex_config_fixture(request: pytest.FixtureRequest):
     try:
         pipelex_instance = pipelex.pipelex.Pipelex.make(
             library_dirs=["examples"],
-            disable_inference=is_inference_disabled_in_pipelex(request),
+            needs_inference=needs_inference_in_pipelex(request),
         )
     except Exception as exc:
         Console().print(Traceback())

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,7 +1,7 @@
 import pipelex.config
 import pipelex.pipelex
 import pytest
-from pipelex.test_extras.shared_pytest_plugins import is_inference_disabled_in_pipelex
+from pipelex.test_extras.shared_pytest_plugins import needs_inference_in_pipelex
 from rich import print
 from rich.console import Console
 from rich.traceback import Traceback
@@ -13,7 +13,7 @@ def reset_pipelex_config_fixture(request: pytest.FixtureRequest):
     print("\n[magenta]pipelex setup[/magenta]")
     try:
         pipelex_instance = pipelex.pipelex.Pipelex.make(
-            disable_inference=is_inference_disabled_in_pipelex(request),
+            needs_inference=needs_inference_in_pipelex(request),
         )
     except Exception as exc:
         Console().print(Traceback())

--- a/uv.lock
+++ b/uv.lock
@@ -3132,7 +3132,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.18.3"
+version = "0.18.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -3170,8 +3170,9 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/27/b2/5bc70a44456eed2ef704ae8582d1b40635b7f6850b94d388eafa1d98a123/pipelex-0.18.5.tar.gz", hash = "sha256:d9bbc73351eae45a38efe1d3a4b1a2cfa6f458733fccac0f2e6a530b96842114", size = 697498, upload-time = "2026-03-02T00:51:57.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/fc/890467183569a321f9f87d22037839be1327353ce92f7ba63408a8d4932c/pipelex-0.18.3-py3-none-any.whl", hash = "sha256:d593d40424582f9bf7e254888a3eaafe35c88667fd5056b8985bd9ab83cd2935", size = 1028553, upload-time = "2026-02-28T02:19:44.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/8b/c7dc2c2f6c15f6e094b2edc56702520ea93cf1731bccbf1a802f3c83aad6/pipelex-0.18.5-py3-none-any.whl", hash = "sha256:c461eb74a73b668935e53ed8475896316e1fbe1971d8ebdaacc4125928128292", size = 1029477, upload-time = "2026-03-02T00:51:55.452Z" },
 ]
 
 [package.optional-dependencies]
@@ -3201,7 +3202,7 @@ mistralai = [
 
 [[package]]
 name = "pipelex-cookbook"
-version = "0.10.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -3239,7 +3240,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = "==4.13.4" },
     { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "google-genai", "bedrock", "fal", "docling"], specifier = "==0.18.3" },
+    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "google-genai", "bedrock", "fal", "docling"], specifier = "==0.18.5" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.405" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk version/dependency bump plus a small test-fixture parameter rename; main potential impact is test setup behavior changing with the updated `Pipelex.make()` API.
> 
> **Overview**
> Cuts release `v0.11.1` by bumping the project version and upgrading the pinned `pipelex` dependency from `0.18.3` to `0.18.5` (including lockfile updates).
> 
> Updates unit/integration test setup to match the new Pipelex test/plugin and `Pipelex.make()` API by replacing `disable_inference`/`is_inference_disabled_in_pipelex` with `needs_inference`/`needs_inference_in_pipelex`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f75179d2b6f030bc8c5adfc55aa4e28178c223c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->