### PR TITLE
Publish the example plugin under the kernel entry-point group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **`hello-inference-plugin` now publishes under the `pipelex.plugins.kernel` entry-point group (Breaking).** Pipelex split plugin discovery by layer: `pipelex.plugins.kernel` for plugins whose adapters are all kernel-layer, `pipelex.plugins.interpreter` for anything that constructs a `Pipe`-aware object. An inference backend constructs a worker, never a `Pipe`, so the example plugin is kernel-layer — and being in the kernel group is what makes it discoverable by a kernel-only boot. The single `pipelex.plugins` group is retired: a Pipelex carrying the split fails startup on any plugin still declared there, so this change must be installed together with the Pipelex release that carries layer-split discovery. The example's `pyproject.toml` and README now explain what the group choice means, since demonstrating the plugin seam is the whole point of the example.
 
+### Fixed
+
+- **`hello-inference-plugin` declares `requires-python = ">=3.11"`.** It still claimed `>=3.10`, a floor the cookbook dropped in v0.16.0, so the example advertised a Python it is no longer tested on.
+
 ## [v0.16.0] - 2026-08-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **`hello-inference-plugin` now publishes under the `pipelex.plugins.kernel` entry-point group (Breaking).** Pipelex split plugin discovery by layer: `pipelex.plugins.kernel` for plugins whose adapters are all kernel-layer, `pipelex.plugins.interpreter` for anything that constructs a `Pipe`-aware object. An inference backend constructs a worker, never a `Pipe`, so the example plugin is kernel-layer — and being in the kernel group is what makes it discoverable by a kernel-only boot. The single `pipelex.plugins` group is retired: a Pipelex carrying the split fails startup on any plugin still declared there, so this change must be installed together with the Pipelex release that carries layer-split discovery. The example's `pyproject.toml` and README now explain what the group choice means, since demonstrating the plugin seam is the whole point of the example.
+
 ## [v0.16.0] - 2026-08-01
 
 ### Added

--- a/examples/c_advanced/using_inference_plugins/README.md
+++ b/examples/c_advanced/using_inference_plugins/README.md
@@ -6,7 +6,7 @@ This example shows how Pipelex discovers **inference-backend plugins**: installa
 
 - `hello_plugin.mthds` — a one-pipe method whose model handle `hello-1` resolves to the plugin's backend.
 - `hello_inference_plugin/` — the plugin package:
-  - `pyproject.toml` declares the `pipelex.plugins` entry point. That single line is the whole integration: once the package is installed, Pipelex discovers the plugin automatically — presence is the source of truth, there is no enable-list.
+  - `pyproject.toml` declares the `pipelex.plugins.kernel` entry point. That single line is the whole integration: once the package is installed, Pipelex discovers the plugin automatically — presence is the source of truth, there is no enable-list.
   - `hello_inference_plugin/hello_plugin.py` — the `HelloInferencePlugin` class (`name`, `targets_api`, and a side-effect-free `register` that contributes an inference backend for `(family="llm", sdk="hello")` plus an optional model lister).
   - `hello_inference_plugin/hello_llm_worker.py` — the worker: subclasses `LLMWorkerAbstract` and implements `_gen_text` deterministically.
   - `hello_inference_plugin/hello_list.py` — the optional lister behind `pipelex show models hello`.

--- a/examples/c_advanced/using_inference_plugins/hello_inference_plugin/pyproject.toml
+++ b/examples/c_advanced/using_inference_plugins/hello_inference_plugin/pyproject.toml
@@ -6,9 +6,14 @@ requires-python = ">=3.10"
 dependencies = ["pipelex"]
 
 # This is the whole plugin wiring: once this distribution is installed,
-# Pipelex discovers the plugin automatically through the `pipelex.plugins`
+# Pipelex discovers the plugin automatically through the `pipelex.plugins.kernel`
 # entry-point group — no config, no enable-list. Presence is the source of truth.
-[project.entry-points."pipelex.plugins"]
+#
+# The *group* declares the layer. An inference backend constructs a worker, never a Pipe, so it is
+# kernel-layer and belongs in the kernel group — which is also the group a kernel-only boot reads.
+# Published under `pipelex.plugins.interpreter` instead, this plugin would simply never be found by
+# such a boot. The pre-split single `pipelex.plugins` group is retired and now fails startup.
+[project.entry-points."pipelex.plugins.kernel"]
 hello_inference = "hello_inference_plugin.hello_plugin:HelloInferencePlugin"
 
 [build-system]

--- a/examples/c_advanced/using_inference_plugins/hello_inference_plugin/pyproject.toml
+++ b/examples/c_advanced/using_inference_plugins/hello_inference_plugin/pyproject.toml
@@ -2,7 +2,7 @@
 name = "hello-inference-plugin"
 version = "0.1.0"
 description = "Minimal Pipelex inference-backend plugin: a deterministic, zero-key 'hello' LLM"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = ["pipelex"]
 
 # This is the whole plugin wiring: once this distribution is installed,


### PR DESCRIPTION
## What

Publishes the `hello-inference-plugin` example under the `pipelex.plugins.kernel` entry-point group, following Pipelex's split of plugin discovery by layer.

## Why

Pipelex now discovers plugins through two groups instead of one:

- `pipelex.plugins.kernel` — plugins whose adapters are all kernel-layer
- `pipelex.plugins.interpreter` — anything that constructs a `Pipe`-aware object

An inference backend constructs a worker, never a `Pipe`, so this example is kernel-layer. Being in the kernel group is also what makes it discoverable by a kernel-only boot: published under `pipelex.plugins.interpreter`, it would simply never be found.

The pre-split single `pipelex.plugins` group is retired — a Pipelex carrying the split fails startup on any plugin still declared there.

## Changes

- `hello_inference_plugin/pyproject.toml` — entry-point group moved to `pipelex.plugins.kernel`, with a comment explaining what the group choice means (the plugin seam is the whole point of this example).
- `examples/c_advanced/using_inference_plugins/README.md` — matching group name.
- `CHANGELOG.md` — `Unreleased` / Changed entry, marked breaking.

## Compatibility

Breaking: this must be installed together with the Pipelex release that carries layer-split discovery. An older Pipelex will not find the plugin in the new group; a newer Pipelex fails startup on the old group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fE4KNyFGvh6dwWVhie7LG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes the `hello-inference-plugin` under the `pipelex.plugins.kernel` entry-point group and raises its Python floor to 3.11. Newer Pipelex discovers kernel-layer plugins via `pipelex.plugins.kernel`; the retired `pipelex.plugins` group triggers startup failure, and 3.11 matches the cookbook’s supported versions.

- Updates `pyproject.toml`: move entry point to `pipelex.plugins.kernel`; set `requires-python = ">=3.11"`. README references the new group.
- Migration:
  - Use with the Pipelex release that introduces layer-split discovery; older Pipelex will not see plugins in `pipelex.plugins.kernel`.
  - Python 3.10 environments must upgrade to 3.11+ or pin to a pre-change example.
- Reviewer focus: confirm discovery under a kernel-only boot and that packaging enforces 3.11+.

<sup>Written for commit 2eeca340951d9cc22783d4b8eaaed391d437a631. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/pipelex-cookbook/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

