### PR TITLE
Bump pipelex to 0.46.4 and migrate the .pipelex config

### DIFF
--- a/.pipelex/.gitignore
+++ b/.pipelex/.gitignore
@@ -1,0 +1,9 @@
+# Written by pipelex when it set this directory up. Yours from here on — pipelex reads this file
+# never, and rewrites it never. Delete a line and it stays deleted.
+#
+# The timestamped copy `pipelex migrate` takes of every file before it rewrites it. It is our own
+# transient artifact; the durable history of these files is your commits.
+#
+# A `<file>.rescue.<stamp>` copy is deliberately NOT listed. One of those exists only because a
+# write could not be vouched for, and seeing it in `git status` is how you find out.
+*.bak.[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]T[0-9][0-9][0-9][0-9][0-9][0-9]Z

--- a/.pipelex/inference/backends/anthropic.toml
+++ b/.pipelex/inference/backends/anthropic.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "anthropic"
-prompting_target = "anthropic"
 structure_method = "instructor/anthropic_tools"
 thinking_mode = "manual"
 

--- a/.pipelex/inference/backends/azure_openai.toml
+++ b/.pipelex/inference/backends/azure_openai.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "azure_openai_responses"
-prompting_target = "openai"
 structure_method = "instructor/openai_responses_tools"
 thinking_mode = "none"
 

--- a/.pipelex/inference/backends/bedrock.toml
+++ b/.pipelex/inference/backends/bedrock.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "bedrock_aioboto3"
-prompting_target = "anthropic"
 thinking_mode = "none"
 
 ################################################################################

--- a/.pipelex/inference/backends/fal.toml
+++ b/.pipelex/inference/backends/fal.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "img_gen"
 sdk = "fal"
-prompting_target = "fal"
 thinking_mode = "none"
 
 ################################################################################

--- a/.pipelex/inference/backends/google.toml
+++ b/.pipelex/inference/backends/google.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "google"
-prompting_target = "gemini"
 structure_method = "instructor/genai_tools"
 thinking_mode = "manual"
 

--- a/.pipelex/inference/backends/minimax.toml
+++ b/.pipelex/inference/backends/minimax.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "anthropic"
-prompting_target = "anthropic"
 structure_method = "instructor/anthropic_tools"
 thinking_mode = "manual"
 max_tokens = 16384

--- a/.pipelex/inference/backends/mistral.toml
+++ b/.pipelex/inference/backends/mistral.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "mistral"
-prompting_target = "mistral"
 structure_method = "instructor/mistral_tools"
 thinking_mode = "none"
 

--- a/.pipelex/inference/backends/ollama.toml
+++ b/.pipelex/inference/backends/ollama.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "openai"
-prompting_target = "anthropic"
 structure_method = "instructor/openai_tools"
 thinking_mode = "none"
 

--- a/.pipelex/inference/backends/openai.toml
+++ b/.pipelex/inference/backends/openai.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "openai_responses"
-prompting_target = "openai"
 structure_method = "instructor/openai_responses_tools"
 thinking_mode = "none"
 

--- a/.pipelex/inference/backends/portkey.toml
+++ b/.pipelex/inference/backends/portkey.toml
@@ -23,7 +23,6 @@
 model_type = "llm"
 sdk = "portkey_completions"
 structure_method = "instructor/openai_tools"
-prompting_target = "anthropic"
 thinking_mode = "none"
 
 ################################################################################
@@ -265,7 +264,6 @@ outputs = ["text", "structured"]
 max_prompt_images = 3000
 costs = { input = 1.25, output = 10.0 }
 thinking_mode = "manual"
-prompting_target = "gemini"
 x-portkey-provider = "@google"
 
 ["gemini-2.5-flash"]
@@ -274,7 +272,6 @@ inputs = ["text", "images", "pdf"]
 outputs = ["text", "structured"]
 costs = { input = 0.30, output = 2.50 }
 thinking_mode = "manual"
-prompting_target = "gemini"
 x-portkey-provider = "@google"
 
 ["gemini-2.5-flash-lite"]
@@ -283,7 +280,6 @@ inputs = ["text", "images", "pdf"]
 outputs = ["text", "structured"]
 costs = { input = 0.10, output = 0.40 }
 thinking_mode = "manual"
-prompting_target = "gemini"
 x-portkey-provider = "@google"
 
 ["gemini-3.1-pro"]
@@ -293,7 +289,6 @@ outputs = ["text", "structured"]
 max_prompt_images = 3000
 costs = { input = 2, output = 12.0 }
 thinking_mode = "adaptive"
-prompting_target = "gemini"
 x-portkey-provider = "@google"
 
 ["gemini-3.0-flash"]
@@ -303,5 +298,4 @@ outputs = ["text", "structured"]
 max_prompt_images = 3000
 costs = { input = 0.5, output = 3.0 }
 thinking_mode = "adaptive"
-prompting_target = "gemini"
 x-portkey-provider = "@google"

--- a/.pipelex/inference/backends/vertexai.toml
+++ b/.pipelex/inference/backends/vertexai.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "openai"
-prompting_target = "gemini"
 structure_method = "instructor/vertexai_tools"
 thinking_mode = "none"
 

--- a/.pipelex/inference/backends/xai.toml
+++ b/.pipelex/inference/backends/xai.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "openai"
-prompting_target = "anthropic"
 structure_method = "instructor/openai_tools"
 thinking_mode = "none"
 

--- a/.pipelex/pipelex.toml
+++ b/.pipelex/pipelex.toml
@@ -30,27 +30,27 @@
 # Pipeline Execution Config
 ####################################################################################################
 
-[pipelex.pipeline_execution_config]
+[interpreter.pipeline_execution]
 # Set to false to disable conversion of incoming data URLs to pipelex-storage:// URIs
 is_normalize_data_urls_to_storage = true
 # Set to false to disable generation of execution graphs
 is_generate_graph = true
 
-[pipelex.pipeline_execution_config.graph_config.data_inclusion]
+[interpreter.pipeline_execution.graph.data_inclusion]
 # Control what data is included in graph outputs
 stuff_json_content = true
 stuff_text_content = true
 stuff_html_content = true
 error_stack_traces = true
 
-[pipelex.pipeline_execution_config.graph_config.graphs_inclusion]
+[interpreter.pipeline_execution.graph.graphs_inclusion]
 # Control which graph outputs are generated
 graphspec_json = true
 mermaidflow_mmd = true
 mermaidflow_html = true
 reactflow_html = true
 
-[pipelex.pipeline_execution_config.graph_config.reactflow_config]
+[interpreter.pipeline_execution.graph.reactflow]
 # Customize ReactFlow graph rendering
 edge_type = "bezier" # Options: "bezier", "smoothstep", "step", "straight"
 nodesep = 50         # Horizontal spacing between nodes
@@ -59,45 +59,10 @@ initial_zoom = 1.0   # Initial zoom level (1.0 = 100%)
 pan_to_top = true    # Pan to show top of graph on load
 
 ####################################################################################################
-# Storage Config
-####################################################################################################
-
-[pipelex.storage_config]
-# Storage method: "local", "in_memory" (default), "s3", or "gcp"
-method = "in_memory"
-# Whether to fetch remote HTTP URLs and store them locally
-is_fetch_remote_content_enabled = true
-# Whether to upload local file paths to storage and replace with pipelex-storage:// URIs
-is_upload_local_content_enabled = true
-
-[pipelex.storage_config.local]
-# Local storage settings
-uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
-local_storage_path = ".pipelex/storage"
-
-[pipelex.storage_config.in_memory]
-# In-memory storage settings
-uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
-
-[pipelex.storage_config.s3]
-# AWS S3 storage settings (requires boto3: `uv pip install "pipelex[s3]"`)
-uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
-bucket_name = ""
-region = ""
-signed_urls_lifespan_seconds = 3600                           # Set to "disabled" for public URLs
-
-[pipelex.storage_config.gcp]
-# Google Cloud Storage settings (requires google-cloud-storage: `uv pip install "pipelex[gcp-storage]"`)
-uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
-bucket_name = ""
-project_id = ""
-signed_urls_lifespan_seconds = 3600                           # Set to "disabled" for public URLs
-
-####################################################################################################
 # Scan Config
 ####################################################################################################
 
-[pipelex.scan_config]
+[interpreter.scan]
 # Directories to exclude when scanning for pipeline files
 excluded_dirs = [
   ".venv",
@@ -119,24 +84,80 @@ excluded_dirs = [
 # Builder Config
 ####################################################################################################
 
-[pipelex.builder_config]
+[interpreter.builder]
 # Settings for generated pipelines
 default_output_dir = "."
 default_bundle_file_name = "bundle"
 default_directory_base_name = "pipeline"
 
 ####################################################################################################
+# Cogt (Cognitive Tools) Config
+####################################################################################################
+
+[inference.model_deck]
+# Model fallback behavior: if true, uses secondary model options when primary fails
+is_model_fallback_enabled = true
+# Reaction to missing presets: "raise", "log", or "none"
+missing_presets_reaction = "log"
+
+[inference.llm]
+# Enable dumping of LLM inputs/outputs for debugging
+is_dump_text_prompts_enabled = false
+is_dump_response_text_enabled = false
+
+[inference.llm.instructor]
+# Enable dumping of structured content generation details for debugging
+is_dump_kwargs_enabled = false
+is_dump_response_enabled = false
+is_dump_error_enabled = false
+
+####################################################################################################
+# Storage Config
+####################################################################################################
+
+[runtime.storage]
+# Storage method: "local", "in_memory" (default), "s3", or "gcp"
+method = "in_memory"
+# Whether to fetch remote HTTP URLs and store them locally
+is_fetch_remote_content_enabled = true
+# Whether to upload local file paths to storage and replace with pipelex-storage:// URIs
+is_upload_local_content_enabled = true
+
+[runtime.storage.local]
+# Local storage settings
+uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
+local_storage_path = ".pipelex/storage"
+
+[runtime.storage.in_memory]
+# In-memory storage settings
+uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
+
+[runtime.storage.s3]
+# AWS S3 storage settings (requires boto3: `uv pip install "pipelex[s3]"`)
+uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
+bucket_name = ""
+region = ""
+signed_urls_lifespan_seconds = 3600                           # Set to "disabled" for public URLs
+
+[runtime.storage.gcp]
+# Google Cloud Storage settings (requires google-cloud-storage: `uv pip install "pipelex[gcp-storage]"`)
+uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
+bucket_name = ""
+project_id = ""
+signed_urls_lifespan_seconds = 3600                           # Set to "disabled" for public URLs
+
+####################################################################################################
 # Log Config
 ####################################################################################################
 
-[pipelex.log_config]
+[runtime.log]
 # Default logging level: "DEBUG", "INFO", "WARNING", "ERROR"
 default_log_level = "INFO"
 # Log output target: "stdout" or "stderr"
 console_log_target = "stdout"
 console_print_target = "stdout"
 
-[pipelex.log_config.package_log_levels]
+[runtime.log.package_log_levels]
 # Log levels for specific packages (use "-" instead of "." in package names)
 pipelex = "INFO"
 
@@ -144,7 +165,7 @@ pipelex = "INFO"
 # Reporting Config
 ####################################################################################################
 
-[pipelex.reporting_config]
+[runtime.reporting]
 # Cost reporting settings
 is_log_costs_to_console = false
 is_generate_cost_report_file_enabled = false
@@ -152,24 +173,3 @@ cost_report_dir_path = "reports"
 cost_report_base_name = "cost_report"
 cost_report_extension = "csv"
 cost_report_unit_scale = 1.0
-
-####################################################################################################
-# Cogt (Cognitive Tools) Config
-####################################################################################################
-
-[cogt.model_deck_config]
-# Model fallback behavior: if true, uses secondary model options when primary fails
-is_model_fallback_enabled = true
-# Reaction to missing presets: "raise", "log", or "none"
-missing_presets_reaction = "log"
-
-[cogt.llm_config]
-# Enable dumping of LLM inputs/outputs for debugging
-is_dump_text_prompts_enabled = false
-is_dump_response_text_enabled = false
-
-[cogt.llm_config.instructor_config]
-# Enable dumping of structured content generation details for debugging
-is_dump_kwargs_enabled = false
-is_dump_response_enabled = false
-is_dump_error_enabled = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 
 dependencies = [
   "beautifulsoup4==4.13.4",
-  "pipelex[mistralai,anthropic,google,google-genai,bedrock,fal,docling]==0.45.0",
+  "pipelex[mistralai,anthropic,google,google-genai,bedrock,fal,docling]==0.46.4",
   "weasyprint==68.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -3792,10 +3792,11 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.45.0"
+version = "0.46.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
+    { name = "annotated-types" },
     { name = "datamodel-code-generator" },
     { name = "filetype" },
     { name = "httpx" },
@@ -3833,9 +3834,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/a8/9157a3f0f5362f013dbcfcffd88497a80ec8364c9f829bc0bdca0629c994/pipelex-0.45.0.tar.gz", hash = "sha256:279c0bb250edfb8aa553e368942acfe4e55a0fa6511b1dd85146b8b8d7b609b6", size = 1246259, upload-time = "2026-08-14T13:18:14.124Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/5f/3747963f8e1c5a2c2f0c4b452962df1ef5da3e2e4feee32bf3f7e6916637/pipelex-0.46.4.tar.gz", hash = "sha256:6ed3e41c41335757ecd55980473ba83c5c807405b29ee5e43fe8d3ebadf5611e", size = 1415544, upload-time = "2026-08-18T18:35:54.415Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/3a/79c86531ad5823ba3de59c238810c242025102f6309b3c35de0ee03c1425/pipelex-0.45.0-py3-none-any.whl", hash = "sha256:afca0eccf02a1ec96fc08243754b8bdf04bf0de17326357a3b79cf5c3b1d12b0", size = 1740578, upload-time = "2026-08-14T13:18:11.882Z" },
+    { url = "https://files.pythonhosted.org/packages/29/21/48790f2874a8155e9b4e3fc60d8f7daa05c088f4d21872f8a6e4368c781a/pipelex-0.46.4-py3-none-any.whl", hash = "sha256:b5d9914938cff19d8d0a5bb958537bc7f103cf965afc5897adc13b93b41fab3f", size = 1950918, upload-time = "2026-08-18T18:35:52.717Z" },
 ]
 
 [package.optional-dependencies]
@@ -3908,7 +3909,7 @@ requires-dist = [
     { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
     { name = "crewai", marker = "extra == 'crewai'", specifier = ">=0.80.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "google-genai", "bedrock", "fal", "docling"], specifier = "==0.45.0" },
+    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "google-genai", "bedrock", "fal", "docling"], specifier = "==0.46.4" },
     { name = "pipelex-tools", marker = "extra == 'dev'", specifier = ">=0.3.2" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.411" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.1" },


### PR DESCRIPTION
## Summary

Upgrades the pipelex dependency from 0.45.0 to 0.46.4 and applies the configuration migration that release requires.

## What changed

- **`pyproject.toml` / `uv.lock`** — pipelex pinned at `0.46.4` (adds a transitive `annotated-types` dependency).
- **Backend TOMLs** — the `prompting_target` key is removed from every backend's `[defaults]` and from the per-model Gemini entries in `portkey.toml`; pipelex no longer reads it.
- **`.pipelex/pipelex.toml`** — sections move off the flat `pipelex.*` / `cogt.*` namespaces onto the new layered ones: `interpreter.*` for pipeline execution, scanning and the builder; `inference.*` for the model deck and LLM/instructor dump settings; `runtime.*` for storage, logging and reporting.
- **`.pipelex/.gitignore`** (new) — written by pipelex to ignore the timestamped `*.bak.<stamp>` copies `pipelex migrate` takes before rewriting a file. `*.rescue.<stamp>` files are deliberately not ignored, so an unverified write still shows up in `git status`.

## Notes

The config changes were produced by `pipelex migrate`, not hand-edited. No `.rescue` files were left behind, meaning every rewrite verified cleanly. The transient `.bak` copies stay untracked and can be deleted locally once the diff is reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016apR3QQaCkX5RyUGX2xqUE


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `pipelex` to 0.46.4 and migrates the workspace config to the new layered schema to keep the project compatible with the release. The old `pipelex.*`/`cogt.*` keys move to `interpreter.*`, `inference.*`, and `runtime.*`; backends drop the now-ignored `prompting_target` key. No behavior change is expected.

- Bumps `pipelex` in `pyproject.toml` and `uv.lock`; adds transitive `annotated-types`.
- Rewrites `.pipelex/pipelex.toml`: pipeline execution and graph -> `interpreter.pipeline_execution.*`; scan and builder -> `interpreter.*`; model deck and LLM/instructor dump -> `inference.*`; storage, logs, reporting -> `runtime.*`.
- Removes `prompting_target` from all backend defaults and Gemini entries in `portkey.toml`.
- Adds `.pipelex/.gitignore` to ignore timestamped `*.bak.<stamp>` files; `*.rescue.<stamp>` remain visible.

**Review and rollout**
- Focus review on the config namespace moves and the `prompting_target` removals.
- After merge: run `uv sync` to install `pipelex` 0.46.4. Optional: delete any local `.pipelex/*.bak.*` backups.

<sup>Written for commit 6c361d4c4ff2a2acdf3ca1998701a969224e4573. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/pipelex-cookbook/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

