### PR TITLE
Release v0.17.0

### DIFF
--- a/.pipelex/.gitignore
+++ b/.pipelex/.gitignore
@@ -1,0 +1,9 @@
+# Written by pipelex when it set this directory up. Yours from here on — pipelex reads this file
+# never, and rewrites it never. Delete a line and it stays deleted.
+#
+# The timestamped copy `pipelex migrate` takes of every file before it rewrites it. It is our own
+# transient artifact; the durable history of these files is your commits.
+#
+# A `<file>.rescue.<stamp>` copy is deliberately NOT listed. One of those exists only because a
+# write could not be vouched for, and seeing it in `git status` is how you find out.
+*.bak.[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]T[0-9][0-9][0-9][0-9][0-9][0-9]Z

--- a/.pipelex/inference/backends/anthropic.toml
+++ b/.pipelex/inference/backends/anthropic.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "anthropic"
-prompting_target = "anthropic"
 structure_method = "instructor/anthropic_tools"
 thinking_mode = "manual"
 

--- a/.pipelex/inference/backends/azure_openai.toml
+++ b/.pipelex/inference/backends/azure_openai.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "azure_openai_responses"
-prompting_target = "openai"
 structure_method = "instructor/openai_responses_tools"
 thinking_mode = "none"
 

--- a/.pipelex/inference/backends/bedrock.toml
+++ b/.pipelex/inference/backends/bedrock.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "bedrock_aioboto3"
-prompting_target = "anthropic"
 thinking_mode = "none"
 
 ################################################################################

--- a/.pipelex/inference/backends/fal.toml
+++ b/.pipelex/inference/backends/fal.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "img_gen"
 sdk = "fal"
-prompting_target = "fal"
 thinking_mode = "none"
 
 ################################################################################

--- a/.pipelex/inference/backends/google.toml
+++ b/.pipelex/inference/backends/google.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "google"
-prompting_target = "gemini"
 structure_method = "instructor/genai_tools"
 thinking_mode = "manual"
 

--- a/.pipelex/inference/backends/minimax.toml
+++ b/.pipelex/inference/backends/minimax.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "anthropic"
-prompting_target = "anthropic"
 structure_method = "instructor/anthropic_tools"
 thinking_mode = "manual"
 max_tokens = 16384

--- a/.pipelex/inference/backends/mistral.toml
+++ b/.pipelex/inference/backends/mistral.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "mistral"
-prompting_target = "mistral"
 structure_method = "instructor/mistral_tools"
 thinking_mode = "none"
 

--- a/.pipelex/inference/backends/ollama.toml
+++ b/.pipelex/inference/backends/ollama.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "openai"
-prompting_target = "anthropic"
 structure_method = "instructor/openai_tools"
 thinking_mode = "none"
 

--- a/.pipelex/inference/backends/openai.toml
+++ b/.pipelex/inference/backends/openai.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "openai_responses"
-prompting_target = "openai"
 structure_method = "instructor/openai_responses_tools"
 thinking_mode = "none"
 

--- a/.pipelex/inference/backends/portkey.toml
+++ b/.pipelex/inference/backends/portkey.toml
@@ -23,7 +23,6 @@
 model_type = "llm"
 sdk = "portkey_completions"
 structure_method = "instructor/openai_tools"
-prompting_target = "anthropic"
 thinking_mode = "none"
 
 ################################################################################
@@ -265,7 +264,6 @@ outputs = ["text", "structured"]
 max_prompt_images = 3000
 costs = { input = 1.25, output = 10.0 }
 thinking_mode = "manual"
-prompting_target = "gemini"
 x-portkey-provider = "@google"
 
 ["gemini-2.5-flash"]
@@ -274,7 +272,6 @@ inputs = ["text", "images", "pdf"]
 outputs = ["text", "structured"]
 costs = { input = 0.30, output = 2.50 }
 thinking_mode = "manual"
-prompting_target = "gemini"
 x-portkey-provider = "@google"
 
 ["gemini-2.5-flash-lite"]
@@ -283,7 +280,6 @@ inputs = ["text", "images", "pdf"]
 outputs = ["text", "structured"]
 costs = { input = 0.10, output = 0.40 }
 thinking_mode = "manual"
-prompting_target = "gemini"
 x-portkey-provider = "@google"
 
 ["gemini-3.1-pro"]
@@ -293,7 +289,6 @@ outputs = ["text", "structured"]
 max_prompt_images = 3000
 costs = { input = 2, output = 12.0 }
 thinking_mode = "adaptive"
-prompting_target = "gemini"
 x-portkey-provider = "@google"
 
 ["gemini-3.0-flash"]
@@ -303,5 +298,4 @@ outputs = ["text", "structured"]
 max_prompt_images = 3000
 costs = { input = 0.5, output = 3.0 }
 thinking_mode = "adaptive"
-prompting_target = "gemini"
 x-portkey-provider = "@google"

--- a/.pipelex/inference/backends/vertexai.toml
+++ b/.pipelex/inference/backends/vertexai.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "openai"
-prompting_target = "gemini"
 structure_method = "instructor/vertexai_tools"
 thinking_mode = "none"
 

--- a/.pipelex/inference/backends/xai.toml
+++ b/.pipelex/inference/backends/xai.toml
@@ -23,7 +23,6 @@
 [defaults]
 model_type = "llm"
 sdk = "openai"
-prompting_target = "anthropic"
 structure_method = "instructor/openai_tools"
 thinking_mode = "none"
 

--- a/.pipelex/pipelex.toml
+++ b/.pipelex/pipelex.toml
@@ -30,27 +30,27 @@
 # Pipeline Execution Config
 ####################################################################################################
 
-[pipelex.pipeline_execution_config]
+[interpreter.pipeline_execution]
 # Set to false to disable conversion of incoming data URLs to pipelex-storage:// URIs
 is_normalize_data_urls_to_storage = true
 # Set to false to disable generation of execution graphs
 is_generate_graph = true
 
-[pipelex.pipeline_execution_config.graph_config.data_inclusion]
+[interpreter.pipeline_execution.graph.data_inclusion]
 # Control what data is included in graph outputs
 stuff_json_content = true
 stuff_text_content = true
 stuff_html_content = true
 error_stack_traces = true
 
-[pipelex.pipeline_execution_config.graph_config.graphs_inclusion]
+[interpreter.pipeline_execution.graph.graphs_inclusion]
 # Control which graph outputs are generated
 graphspec_json = true
 mermaidflow_mmd = true
 mermaidflow_html = true
 reactflow_html = true
 
-[pipelex.pipeline_execution_config.graph_config.reactflow_config]
+[interpreter.pipeline_execution.graph.reactflow]
 # Customize ReactFlow graph rendering
 edge_type = "bezier" # Options: "bezier", "smoothstep", "step", "straight"
 nodesep = 50         # Horizontal spacing between nodes
@@ -59,45 +59,10 @@ initial_zoom = 1.0   # Initial zoom level (1.0 = 100%)
 pan_to_top = true    # Pan to show top of graph on load
 
 ####################################################################################################
-# Storage Config
-####################################################################################################
-
-[pipelex.storage_config]
-# Storage method: "local", "in_memory" (default), "s3", or "gcp"
-method = "in_memory"
-# Whether to fetch remote HTTP URLs and store them locally
-is_fetch_remote_content_enabled = true
-# Whether to upload local file paths to storage and replace with pipelex-storage:// URIs
-is_upload_local_content_enabled = true
-
-[pipelex.storage_config.local]
-# Local storage settings
-uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
-local_storage_path = ".pipelex/storage"
-
-[pipelex.storage_config.in_memory]
-# In-memory storage settings
-uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
-
-[pipelex.storage_config.s3]
-# AWS S3 storage settings (requires boto3: `uv pip install "pipelex[s3]"`)
-uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
-bucket_name = ""
-region = ""
-signed_urls_lifespan_seconds = 3600                           # Set to "disabled" for public URLs
-
-[pipelex.storage_config.gcp]
-# Google Cloud Storage settings (requires google-cloud-storage: `uv pip install "pipelex[gcp-storage]"`)
-uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
-bucket_name = ""
-project_id = ""
-signed_urls_lifespan_seconds = 3600                           # Set to "disabled" for public URLs
-
-####################################################################################################
 # Scan Config
 ####################################################################################################
 
-[pipelex.scan_config]
+[interpreter.scan]
 # Directories to exclude when scanning for pipeline files
 excluded_dirs = [
   ".venv",
@@ -119,24 +84,80 @@ excluded_dirs = [
 # Builder Config
 ####################################################################################################
 
-[pipelex.builder_config]
+[interpreter.builder]
 # Settings for generated pipelines
 default_output_dir = "."
 default_bundle_file_name = "bundle"
 default_directory_base_name = "pipeline"
 
 ####################################################################################################
+# Cogt (Cognitive Tools) Config
+####################################################################################################
+
+[inference.model_deck]
+# Model fallback behavior: if true, uses secondary model options when primary fails
+is_model_fallback_enabled = true
+# Reaction to missing presets: "raise", "log", or "none"
+missing_presets_reaction = "log"
+
+[inference.llm]
+# Enable dumping of LLM inputs/outputs for debugging
+is_dump_text_prompts_enabled = false
+is_dump_response_text_enabled = false
+
+[inference.llm.instructor]
+# Enable dumping of structured content generation details for debugging
+is_dump_kwargs_enabled = false
+is_dump_response_enabled = false
+is_dump_error_enabled = false
+
+####################################################################################################
+# Storage Config
+####################################################################################################
+
+[runtime.storage]
+# Storage method: "local", "in_memory" (default), "s3", or "gcp"
+method = "in_memory"
+# Whether to fetch remote HTTP URLs and store them locally
+is_fetch_remote_content_enabled = true
+# Whether to upload local file paths to storage and replace with pipelex-storage:// URIs
+is_upload_local_content_enabled = true
+
+[runtime.storage.local]
+# Local storage settings
+uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
+local_storage_path = ".pipelex/storage"
+
+[runtime.storage.in_memory]
+# In-memory storage settings
+uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
+
+[runtime.storage.s3]
+# AWS S3 storage settings (requires boto3: `uv pip install "pipelex[s3]"`)
+uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
+bucket_name = ""
+region = ""
+signed_urls_lifespan_seconds = 3600                           # Set to "disabled" for public URLs
+
+[runtime.storage.gcp]
+# Google Cloud Storage settings (requires google-cloud-storage: `uv pip install "pipelex[gcp-storage]"`)
+uri_format = "{primary_id}/{secondary_id}/{hash}.{extension}"
+bucket_name = ""
+project_id = ""
+signed_urls_lifespan_seconds = 3600                           # Set to "disabled" for public URLs
+
+####################################################################################################
 # Log Config
 ####################################################################################################
 
-[pipelex.log_config]
+[runtime.log]
 # Default logging level: "DEBUG", "INFO", "WARNING", "ERROR"
 default_log_level = "INFO"
 # Log output target: "stdout" or "stderr"
 console_log_target = "stdout"
 console_print_target = "stdout"
 
-[pipelex.log_config.package_log_levels]
+[runtime.log.package_log_levels]
 # Log levels for specific packages (use "-" instead of "." in package names)
 pipelex = "INFO"
 
@@ -144,7 +165,7 @@ pipelex = "INFO"
 # Reporting Config
 ####################################################################################################
 
-[pipelex.reporting_config]
+[runtime.reporting]
 # Cost reporting settings
 is_log_costs_to_console = false
 is_generate_cost_report_file_enabled = false
@@ -152,24 +173,3 @@ cost_report_dir_path = "reports"
 cost_report_base_name = "cost_report"
 cost_report_extension = "csv"
 cost_report_unit_scale = 1.0
-
-####################################################################################################
-# Cogt (Cognitive Tools) Config
-####################################################################################################
-
-[cogt.model_deck_config]
-# Model fallback behavior: if true, uses secondary model options when primary fails
-is_model_fallback_enabled = true
-# Reaction to missing presets: "raise", "log", or "none"
-missing_presets_reaction = "log"
-
-[cogt.llm_config]
-# Enable dumping of LLM inputs/outputs for debugging
-is_dump_text_prompts_enabled = false
-is_dump_response_text_enabled = false
-
-[cogt.llm_config.instructor_config]
-# Enable dumping of structured content generation details for debugging
-is_dump_kwargs_enabled = false
-is_dump_response_enabled = false
-is_dump_error_enabled = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Changelog
 
-## [Unreleased]
+## [v0.17.0] - 2026-08-18
 
 ### Changed
 
+- **Pipelex upgraded from `0.42.0` to `0.46.4`, and the workspace configuration migrated with it (Breaking).** Running `pipelex migrate` moved `.pipelex/pipelex.toml` off the flat `pipelex.*` and `cogt.*` namespaces onto the new `interpreter.*`, `inference.*` and `runtime.*` sections, so pipeline execution, model and LLM settings, and storage, logging and reporting each live under the layer that owns them. The backend TOMLs dropped the `prompting_target` key, which pipelex no longer reads, and a `pipelex`-written `.pipelex/.gitignore` keeps the timestamped `*.bak.<stamp>` copies the migration leaves behind out of version control while deliberately leaving `*.rescue.<stamp>` files visible in `git status`. Anyone carrying local edits under `.pipelex/` needs to re-run the migration against their own copy.
 - **`hello-inference-plugin` now publishes under the `pipelex.plugins.kernel` entry-point group (Breaking).** Pipelex split plugin discovery by layer: `pipelex.plugins.kernel` for plugins whose adapters are all kernel-layer, `pipelex.plugins.interpreter` for anything that constructs a `Pipe`-aware object. An inference backend constructs a worker, never a `Pipe`, so the example plugin is kernel-layer — and being in the kernel group is what makes it discoverable by a kernel-only boot. The single `pipelex.plugins` group is retired: a Pipelex carrying the split fails startup on any plugin still declared there, so this change must be installed together with the Pipelex release that carries layer-split discovery. The example's `pyproject.toml` and README now explain what the group choice means, since demonstrating the plugin seam is the whole point of the example.
 
 ### Fixed
 
+- **`advisory_board` qualifies its `present_as_markdown` pipe reference with the presentation domain.** Unqualified, the reference resolved against `master_advisory_orchestrator`'s own `advisory_orchestrator` domain, which broke library loading for the entire test suite rather than only for that one example.
 - **`hello-inference-plugin` declares `requires-python = ">=3.11"`.** It still claimed `>=3.10`, a floor the cookbook dropped in v0.16.0, so the example advertised a Python it is no longer tested on.
 
 ## [v0.16.0] - 2026-08-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **`hello-inference-plugin` now publishes under the `pipelex.plugins.kernel` entry-point group (Breaking).** Pipelex split plugin discovery by layer: `pipelex.plugins.kernel` for plugins whose adapters are all kernel-layer, `pipelex.plugins.interpreter` for anything that constructs a `Pipe`-aware object. An inference backend constructs a worker, never a `Pipe`, so the example plugin is kernel-layer — and being in the kernel group is what makes it discoverable by a kernel-only boot. The single `pipelex.plugins` group is retired: a Pipelex carrying the split fails startup on any plugin still declared there, so this change must be installed together with the Pipelex release that carries layer-split discovery. The example's `pyproject.toml` and README now explain what the group choice means, since demonstrating the plugin seam is the whole point of the example.
 
+### Fixed
+
+- **`hello-inference-plugin` declares `requires-python = ">=3.11"`.** It still claimed `>=3.10`, a floor the cookbook dropped in v0.16.0, so the example advertised a Python it is no longer tested on.
+
 ## [v0.16.0] - 2026-08-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **`hello-inference-plugin` now publishes under the `pipelex.plugins.kernel` entry-point group (Breaking).** Pipelex split plugin discovery by layer: `pipelex.plugins.kernel` for plugins whose adapters are all kernel-layer, `pipelex.plugins.interpreter` for anything that constructs a `Pipe`-aware object. An inference backend constructs a worker, never a `Pipe`, so the example plugin is kernel-layer — and being in the kernel group is what makes it discoverable by a kernel-only boot. The single `pipelex.plugins` group is retired: a Pipelex carrying the split fails startup on any plugin still declared there, so this change must be installed together with the Pipelex release that carries layer-split discovery. The example's `pyproject.toml` and README now explain what the group choice means, since demonstrating the plugin seam is the whole point of the example.
+
 ## [v0.16.0] - 2026-08-01
 
 ### Added

--- a/examples/c_advanced/using_inference_plugins/README.md
+++ b/examples/c_advanced/using_inference_plugins/README.md
@@ -6,7 +6,7 @@ This example shows how Pipelex discovers **inference-backend plugins**: installa
 
 - `hello_plugin.mthds` — a one-pipe method whose model handle `hello-1` resolves to the plugin's backend.
 - `hello_inference_plugin/` — the plugin package:
-  - `pyproject.toml` declares the `pipelex.plugins` entry point. That single line is the whole integration: once the package is installed, Pipelex discovers the plugin automatically — presence is the source of truth, there is no enable-list.
+  - `pyproject.toml` declares the `pipelex.plugins.kernel` entry point. That single line is the whole integration: once the package is installed, Pipelex discovers the plugin automatically — presence is the source of truth, there is no enable-list.
   - `hello_inference_plugin/hello_plugin.py` — the `HelloInferencePlugin` class (`name`, `targets_api`, and a side-effect-free `register` that contributes an inference backend for `(family="llm", sdk="hello")` plus an optional model lister).
   - `hello_inference_plugin/hello_llm_worker.py` — the worker: subclasses `LLMWorkerAbstract` and implements `_gen_text` deterministically.
   - `hello_inference_plugin/hello_list.py` — the optional lister behind `pipelex show models hello`.

--- a/examples/c_advanced/using_inference_plugins/hello_inference_plugin/pyproject.toml
+++ b/examples/c_advanced/using_inference_plugins/hello_inference_plugin/pyproject.toml
@@ -6,9 +6,14 @@ requires-python = ">=3.10"
 dependencies = ["pipelex"]
 
 # This is the whole plugin wiring: once this distribution is installed,
-# Pipelex discovers the plugin automatically through the `pipelex.plugins`
+# Pipelex discovers the plugin automatically through the `pipelex.plugins.kernel`
 # entry-point group — no config, no enable-list. Presence is the source of truth.
-[project.entry-points."pipelex.plugins"]
+#
+# The *group* declares the layer. An inference backend constructs a worker, never a Pipe, so it is
+# kernel-layer and belongs in the kernel group — which is also the group a kernel-only boot reads.
+# Published under `pipelex.plugins.interpreter` instead, this plugin would simply never be found by
+# such a boot. The pre-split single `pipelex.plugins` group is retired and now fails startup.
+[project.entry-points."pipelex.plugins.kernel"]
 hello_inference = "hello_inference_plugin.hello_plugin:HelloInferencePlugin"
 
 [build-system]

--- a/examples/c_advanced/using_inference_plugins/hello_inference_plugin/pyproject.toml
+++ b/examples/c_advanced/using_inference_plugins/hello_inference_plugin/pyproject.toml
@@ -2,7 +2,7 @@
 name = "hello-inference-plugin"
 version = "0.1.0"
 description = "Minimal Pipelex inference-backend plugin: a deterministic, zero-key 'hello' LLM"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = ["pipelex"]
 
 # This is the whole plugin wiring: once this distribution is installed,

--- a/examples/wip/advisory_board/bundle.mthds
+++ b/examples/wip/advisory_board/bundle.mthds
@@ -140,7 +140,7 @@ steps = [
   { pipe = "consult_board", batch_over = "selected_advisory_boards", batch_as = "advisory_board", result = "board_consultations" },
   { pipe = "analyze_board_responses", result = "response_analysis" },
   { pipe = "generate_strategic_report", result = "strategic_report" },
-  { pipe = "present_as_markdown", result = "strategic_report_markdown" },
+  { pipe = "presentation.present_as_markdown", result = "strategic_report_markdown" },
 ]
 
 [pipe.classify_business_problem]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelex-cookbook"
-version = "0.16.0"
+version = "0.17.0"
 description = "Cookbook for Pipelex, the open standard for repeatable AI methods. Write business logic, not API calls."
 authors = [{ name = "Evotis S.A.S.", email = "evotis@pipelex.com" }]
 maintainers = [{ name = "Pipelex staff", email = "oss@pipelex.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 
 dependencies = [
   "beautifulsoup4==4.13.4",
-  "pipelex[mistralai,anthropic,google,google-genai,bedrock,fal,docling]==0.45.0",
+  "pipelex[mistralai,anthropic,google,google-genai,bedrock,fal,docling]==0.46.4",
   "weasyprint==68.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 
 dependencies = [
   "beautifulsoup4==4.13.4",
-  "pipelex[mistralai,anthropic,google,google-genai,bedrock,fal,docling]==0.42.0",
+  "pipelex[mistralai,anthropic,google,google-genai,bedrock,fal,docling]==0.45.0",
   "weasyprint==68.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -7,14 +7,14 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version < '3.12' and sys_platform == 'darwin'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'darwin'",
     "python_full_version < '3.12' and sys_platform == 'win32'",
     "python_full_version < '3.12' and sys_platform == 'emscripten'",
     "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
@@ -1069,7 +1069,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/3a8241c6e19483ac1f1dcf5c10238205dcb8a6e9d0d4d4709240dff28ff4/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:721104c603f059780d287969be3d194a18d0cc3b713ed9049065a1107706759d", size = 5730273, upload-time = "2026-03-11T00:12:37.18Z" },
@@ -1102,37 +1102,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -1988,17 +1988,17 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.12'" },
-    { name = "jedi", marker = "python_full_version < '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.12'" },
-    { name = "pexpect", marker = "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "stack-data", marker = "python_full_version < '3.12'" },
-    { name = "traitlets", marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/25/daae0e764047b0a2480c7bbb25d48f4f509b5818636562eeac145d06dfee/ipython-9.10.1.tar.gz", hash = "sha256:e170e9b2a44312484415bdb750492699bf329233b03f2557a9692cce6466ada4", size = 4426663, upload-time = "2026-03-27T09:53:26.244Z" }
 wheels = [
@@ -2015,25 +2015,25 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/73/7114f80a8f9cabdb13c27732dce24af945b2923dcab80723602f7c8bc2d8/ipython-9.12.0.tar.gz", hash = "sha256:01daa83f504b693ba523b5a407246cabde4eb4513285a3c6acaff11a66735ee4", size = 4428879, upload-time = "2026-03-27T09:42:45.312Z" }
 wheels = [
@@ -3192,7 +3192,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -3204,7 +3204,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3234,9 +3234,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3248,7 +3248,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3696,7 +3696,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3869,7 +3869,7 @@ mistralai = [
 
 [[package]]
 name = "pipelex-cookbook"
-version = "0.16.0"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/uv.lock
+++ b/uv.lock
@@ -3792,10 +3792,11 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.45.0"
+version = "0.46.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
+    { name = "annotated-types" },
     { name = "datamodel-code-generator" },
     { name = "filetype" },
     { name = "httpx" },
@@ -3833,9 +3834,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/a8/9157a3f0f5362f013dbcfcffd88497a80ec8364c9f829bc0bdca0629c994/pipelex-0.45.0.tar.gz", hash = "sha256:279c0bb250edfb8aa553e368942acfe4e55a0fa6511b1dd85146b8b8d7b609b6", size = 1246259, upload-time = "2026-08-14T13:18:14.124Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/5f/3747963f8e1c5a2c2f0c4b452962df1ef5da3e2e4feee32bf3f7e6916637/pipelex-0.46.4.tar.gz", hash = "sha256:6ed3e41c41335757ecd55980473ba83c5c807405b29ee5e43fe8d3ebadf5611e", size = 1415544, upload-time = "2026-08-18T18:35:54.415Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/3a/79c86531ad5823ba3de59c238810c242025102f6309b3c35de0ee03c1425/pipelex-0.45.0-py3-none-any.whl", hash = "sha256:afca0eccf02a1ec96fc08243754b8bdf04bf0de17326357a3b79cf5c3b1d12b0", size = 1740578, upload-time = "2026-08-14T13:18:11.882Z" },
+    { url = "https://files.pythonhosted.org/packages/29/21/48790f2874a8155e9b4e3fc60d8f7daa05c088f4d21872f8a6e4368c781a/pipelex-0.46.4-py3-none-any.whl", hash = "sha256:b5d9914938cff19d8d0a5bb958537bc7f103cf965afc5897adc13b93b41fab3f", size = 1950918, upload-time = "2026-08-18T18:35:52.717Z" },
 ]
 
 [package.optional-dependencies]
@@ -3908,7 +3909,7 @@ requires-dist = [
     { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
     { name = "crewai", marker = "extra == 'crewai'", specifier = ">=0.80.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "google-genai", "bedrock", "fal", "docling"], specifier = "==0.45.0" },
+    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "google-genai", "bedrock", "fal", "docling"], specifier = "==0.46.4" },
     { name = "pipelex-tools", marker = "extra == 'dev'", specifier = ">=0.3.2" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.411" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -1069,7 +1069,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/3a8241c6e19483ac1f1dcf5c10238205dcb8a6e9d0d4d4709240dff28ff4/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:721104c603f059780d287969be3d194a18d0cc3b713ed9049065a1107706759d", size = 5730273, upload-time = "2026-03-11T00:12:37.18Z" },
@@ -1102,37 +1102,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1988,17 +1988,17 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.12'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.12'" },
+    { name = "jedi", marker = "python_full_version < '3.12'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.12'" },
+    { name = "pexpect", marker = "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.12'" },
+    { name = "pygments", marker = "python_full_version < '3.12'" },
+    { name = "stack-data", marker = "python_full_version < '3.12'" },
+    { name = "traitlets", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/25/daae0e764047b0a2480c7bbb25d48f4f509b5818636562eeac145d06dfee/ipython-9.10.1.tar.gz", hash = "sha256:e170e9b2a44312484415bdb750492699bf329233b03f2557a9692cce6466ada4", size = 4426663, upload-time = "2026-03-27T09:53:26.244Z" }
 wheels = [
@@ -2024,16 +2024,16 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
+    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.12'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
+    { name = "jedi", marker = "python_full_version >= '3.12'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
+    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
+    { name = "pygments", marker = "python_full_version >= '3.12'" },
+    { name = "stack-data", marker = "python_full_version >= '3.12'" },
+    { name = "traitlets", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/73/7114f80a8f9cabdb13c27732dce24af945b2923dcab80723602f7c8bc2d8/ipython-9.12.0.tar.gz", hash = "sha256:01daa83f504b693ba523b5a407246cabde4eb4513285a3c6acaff11a66735ee4", size = 4428879, upload-time = "2026-03-27T09:42:45.312Z" }
 wheels = [
@@ -3192,7 +3192,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -3204,7 +3204,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3234,9 +3234,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3248,7 +3248,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3696,7 +3696,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3792,7 +3792,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.42.0"
+version = "0.45.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -3833,9 +3833,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/5e/ccf07098883f1550e3e8af18ede0d2a6dcd065e4b81b829eb6776949a784/pipelex-0.42.0.tar.gz", hash = "sha256:531ffe69a39e772626ab144543841afe28d6bc07b1df6c4dfcf96296250a3b88", size = 1200697, upload-time = "2026-08-01T07:32:57.341Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/a8/9157a3f0f5362f013dbcfcffd88497a80ec8364c9f829bc0bdca0629c994/pipelex-0.45.0.tar.gz", hash = "sha256:279c0bb250edfb8aa553e368942acfe4e55a0fa6511b1dd85146b8b8d7b609b6", size = 1246259, upload-time = "2026-08-14T13:18:14.124Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/b9/cf24f0579725a8e97aadf7b93c98240a22518767eecce4b6e7dc1f6aa40c/pipelex-0.42.0-py3-none-any.whl", hash = "sha256:cf6b352a5c75cbf5fbe24d19014135b827bb3f4eeba28299bdf604691acfb003", size = 1677825, upload-time = "2026-08-01T07:32:55.098Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3a/79c86531ad5823ba3de59c238810c242025102f6309b3c35de0ee03c1425/pipelex-0.45.0-py3-none-any.whl", hash = "sha256:afca0eccf02a1ec96fc08243754b8bdf04bf0de17326357a3b79cf5c3b1d12b0", size = 1740578, upload-time = "2026-08-14T13:18:11.882Z" },
 ]
 
 [package.optional-dependencies]
@@ -3908,7 +3908,7 @@ requires-dist = [
     { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
     { name = "crewai", marker = "extra == 'crewai'", specifier = ">=0.80.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "google-genai", "bedrock", "fal", "docling"], specifier = "==0.42.0" },
+    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "google-genai", "bedrock", "fal", "docling"], specifier = "==0.45.0" },
     { name = "pipelex-tools", marker = "extra == 'dev'", specifier = ">=0.3.2" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.411" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.1" },


### PR DESCRIPTION
Cuts **v0.17.0** of the cookbook. Two breaking changes land together, and both are tied to the Pipelex release this sweeps onto.

## Changed

- **Pipelex upgraded from `0.42.0` to `0.46.4`, with the workspace configuration migrated to match (breaking).** `pipelex migrate` moved `.pipelex/pipelex.toml` off the flat `pipelex.*` and `cogt.*` namespaces onto the new `interpreter.*`, `inference.*` and `runtime.*` sections, so pipeline execution, model and LLM settings, and storage, logging and reporting each sit under the layer that owns them. The backend TOMLs dropped `prompting_target`, which pipelex no longer reads, and a `pipelex`-written `.pipelex/.gitignore` keeps the migration's timestamped `*.bak.<stamp>` copies out of version control while deliberately leaving `*.rescue.<stamp>` files visible in `git status`.
- **`hello-inference-plugin` publishes under the `pipelex.plugins.kernel` entry-point group (breaking).** Pipelex split plugin discovery by layer; an inference backend constructs a worker rather than a `Pipe`, so the example is kernel-layer, and the retired single `pipelex.plugins` group now fails startup. This must be installed alongside the Pipelex release carrying layer-split discovery.

## Fixed

- **`advisory_board` qualifies its `present_as_markdown` pipe reference with the presentation domain.** Unqualified, it resolved against `master_advisory_orchestrator`'s own `advisory_orchestrator` domain, which broke library loading for the whole test suite rather than only that example.
- **`hello-inference-plugin` declares `requires-python = ">=3.11"`**, matching the floor the cookbook adopted in v0.16.0.

## Notes for review

The changelog entry folds in two merged PRs that had shipped without changelog coverage (the pipelex 0.45.0 / 0.46.4 bumps and the `advisory_board` fix), so `[Unreleased]` was incomplete before this branch.

The `uv.lock` diff is wider than the version bump alone: apart from `pipelex-cookbook 0.16.0 -> 0.17.0`, no package version, wheel URL or hash changed — the rest is uv rewriting transitive dependency markers it can infer from the parent package. The same block flipped the other way in 2c0b25f, so it is normalization churn between two uv versions, not a resolution change.

`make agent-check` passes: ruff, plxt, pyright and mypy all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016apR3QQaCkX5RyUGX2xqUE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases v0.17.0. Upgrades `pipelex` from 0.42.0 to 0.46.4 and migrates the workspace config to layered namespaces; retires `prompting_target` in backend TOMLs; moves the example plugin to the `pipelex.plugins.kernel` group; fixes an unqualified pipe reference and aligns the example’s Python floor to >=3.11. Older configs and the retired `pipelex.plugins` group fail under the new `pipelex`.

**Migration and review notes**
- Run `pipelex migrate` to rewrite `.pipelex/pipelex.toml` to `interpreter.*`, `inference.*`, and `runtime.*`, and to drop `prompting_target` in backend TOMLs. The new `.pipelex/.gitignore` ignores `*.bak.<stamp>` but leaves `*.rescue.<stamp>` visible.
- Ensure the example plugin declares `[project.entry-points."pipelex.plugins.kernel"]`; install it with `pipelex` ≥ 0.46 to avoid startup failures from the retired `pipelex.plugins` group.
- The advisory example now calls `presentation.present_as_markdown`; the plugin sets `requires-python = ">=3.11"`.
- `uv.lock` changes are normalization; only `pipelex` and `pipelex-cookbook` versions changed.

<sup>Written for commit c4b18b0bd25746dc88996d7423ff1d9b189e60d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/pipelex-cookbook/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

