### PR TITLE
docs: cut the /release skill down to pipelex-cookbook's specifics

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,127 +1,70 @@
 ---
 name: release
-description: Prepare a new release for the pipelex-cookbook project. Bumps version in pyproject.toml, syncs uv.lock, updates CHANGELOG.md, manages the release/vX.Y.Z branch, runs lint and type checks, and commits. Use when the user says "release", "prepare a release", "bump version", "new version", or "cut a release".
+description: >
+  Cut a release of pipelex-cookbook, the examples and tutorials repo: the
+  release/vX.Y.Z worktree, the pyproject.toml bump and the uv.lock that follows,
+  the changelog entry, the lint and test gates, one commit, and a pull request to
+  main that creates the GitHub Release on merge. Use when the user says
+  "release", "cut a release", "bump version", "prepare a release", "new version",
+  "make a release", "ship it", "create release branch", "promote dev to main", or
+  any variation of shipping a new version of the cookbook. Changelog content
+  passed inline ("/release Added an example for invoice extraction") becomes the
+  entry. The merge is landed by /ledger-land, never by this skill.
 ---
 
-# Release Workflow
+# Releasing pipelex-cookbook
 
-Guides the user through preparing a new pipelex-cookbook release in 8 interactive steps. Every step requires explicit user confirmation before proceeding.
+The procedure is the workspace release play, [`docs/releasing.md`](../../../../docs/releasing.md) at the workspace root — `../docs/releasing.md` from this repo's own root, which resolves the same from the main checkout and from any worktree. Read it first, then run it with what follows. The repo key is `pipelex-cookbook`, the base is `dev`, and the pull request targets `main`: `guard-branches.yml` refuses any head branch but `release/vX.Y.Z` into `main`, so there is no other way in. The release worktree is `_pipelex-cookbook--release`, made with `wt add pipelex-cookbook release --branch release/vX.Y.Z`. The repo declares neither `.worktree.toml` nor `.worktreeinclude`, so `wt` resolves the base from `origin/dev` and provisions with the Makefile's `install` target, which is what creates the `.venv` every gate below runs out of.
 
-## Step 1 — Gather State
+## What ships
 
-Read the following and present a summary:
+Nothing is published to a package registry: there is no publish workflow in `.github/workflows/`, so the play's "the registry's answer" has no counterpart here. What the merge to `main` produces is the GitHub Release and its tag, created by `github-release.yml`, which fires on `push` to `main`:
 
-1. Current version from `pyproject.toml` (`version = "X.Y.Z"`)
-2. Latest entry in `CHANGELOG.md`
-3. Current git branch (`git branch --show-current`)
-4. Working tree status (`git status --short`)
+- It reads the number with `grep -m 1 'version = ' pyproject.toml | cut -d '"' -f 2`, slices the changelog section between `## [vX.Y.Z] - ` and the next `## [v…] - ` heading for the notes, and calls `gh release create "v$VERSION"`.
+- The notes keep the one blank line the step re-inserts after the version heading and lose every other, with leading and trailing whitespace stripped from each remaining line, so nested bullets flatten and a `###` subheading ends up against the bullets under it. When no `## [vX.Y.Z] - ` heading is found the step warns, sets the notes empty and exits 0, so the Release still ships — carrying the bare line `Release vX.Y.Z` instead of failing.
+- Nothing guards the step against a Release that already exists, so a merge to `main` that does not carry a new number fails at `gh release create`. `guard-branches.yml` narrows the exposure by admitting only a `release/vX.Y.Z` head and `version-check.yml` ties that name to `pyproject.toml`, but neither compares the number against what `main` has already released, so re-merging a release branch for a version that already shipped is the way this step can still go red.
 
-If the working tree is dirty, **warn the user** and ask whether to continue or abort.
-
-## Step 2 — Determine Target Version
-
-Calculate the three semver bump options from the current version:
-
-- **Patch**: `X.Y.Z+1`
-- **Minor**: `X.Y+1.0`
-- **Major**: `X+1.0.0`
-
-Present these options to the user using `AskUserQuestion`. If the current branch already looks like `release/vA.B.C` and the version in `pyproject.toml` was already bumped, offer a **"Keep current (A.B.C)"** option.
-
-Store the chosen version as `TARGET_VERSION` (no `v` prefix, e.g. `0.13.0`).
-
-## Step 3 — Branch Management
-
-The release branch **must** be named `release/v{TARGET_VERSION}` (CI regex: `^release/v[0-9]+\.[0-9]+\.[0-9]+$`).
-
-- If already on the correct branch: inform the user and continue.
-- If on `main` or another branch: confirm with the user, then create and switch to `release/v{TARGET_VERSION}`.
-- If on a *different* release branch: warn the user and ask how to proceed.
-
-## Step 4 — Update Version in pyproject.toml
-
-Edit the `version = "..."` line in `pyproject.toml` to `version = "{TARGET_VERSION}"`.
-
-- If the version already matches: inform the user and skip.
-- Otherwise: use the Edit tool to make the change, then show the diff.
-
-The version in pyproject.toml must **not** have a `v` prefix (e.g. `0.13.0`, not `v0.13.0`).
-
-## Step 5 — Sync uv.lock
-
-After updating `pyproject.toml`, regenerate the lock file so it reflects `TARGET_VERSION`:
+The landing verifies the publish from the run, the Release and the tag:
 
 ```bash
-uv lock
+gh run list --workflow=github-release.yml --branch main --limit 3 --json conclusion,headSha,url  # the run whose headSha is the merge SHA: success
+gh release view vX.Y.Z                                                                          # the Release and its notes
+git fetch --tags --prune origin && git tag --list vX.Y.Z                                        # the tag
 ```
 
-Verify the output confirms the version was updated (e.g. `Updated pipelex-cookbook vX.Y.Z -> v{TARGET_VERSION}`).
+## Version files and the lock
 
-- **If the lock file was already in sync**: inform the user and continue.
-- **On failure**: show the error and ask the user how to proceed.
+- **`pyproject.toml`** — the `[project]` table's `version`, the one and only place the number is written, with no `v` prefix. Keep it the file's **first** `version = ` line and keep it at column zero: `github-release.yml` reads it with `grep -m 1 'version = '`, which `required-version` under `[tool.uv]` would otherwise match, and `version-check.yml` reads it with `grep '^version'`.
+- **`uv.lock`** — the lockfile records the project's own version in its `pipelex-cookbook` entry, so it must be regenerated after the bump: `make lock` (`uv lock`), or `make li` (lock, then install) when the worktree's environment should be synced at the same time. If it fails, stop and report it rather than committing a stale lock.
+- **Also stamped:** nothing. There is no README badge and no `__version__`. `requirements.txt` and `requirements-dev.txt` are exports of the lockfile made by `make export-requirements` and `make export-requirements-dev`, but they carry no version of the cookbook itself, so a bump leaves them untouched and they stay out of the release commit.
 
-## Step 6 — Update CHANGELOG.md
+## Gates
 
-The changelog entry **must** match the CI grep pattern: `## [vX.Y.Z] -`
+Run in the worktree, in this order, before the commit:
 
-Check if `CHANGELOG.md` already contains a `## [v{TARGET_VERSION}] -` entry.
+1. `make agent-check` — `fix-unused-imports`, then `format` (`ruff format` and `plxt fmt`), `lint` (`ruff check --fix` and `plxt lint`), `pyright` and `mypy`. **It rewrites files**, so whatever it touched joins the release commit. Red blocks the release: fix the code, never loosen the target. The `plxt` half matters most here, because `lint-check.yml` runs only the ruff, pyright and mypy merge checks — the formatting and linting of the `.mthds` and TOML sources is enforced by this gate and nowhere else.
+2. `make agent-test` — the pytest suite under the Makefile's usual markers, `"(dry_runnable or not inference) and not (needs_output or pipelex_api)"`, quiet unless it fails. `tests-check.yml` runs `make gha-tests` on the pull request across its 3.11, 3.12 and 3.13 matrix, and that target selects differently (`--disable-inference` with `-m "not inference and not gha_disabled"`), so a green run here is not a promise of a green matrix there — but a red one here is a red pull request.
 
-- **If exists**: show the existing entry and ask the user whether to keep it or edit it.
+## The release commit
 
-- **If missing**: check whether `CHANGELOG.md` has an `## [Unreleased]` or `## Unreleased` section.
+`pyproject.toml`, `uv.lock`, `CHANGELOG.md`, and each file `make agent-check` rewrote — staged by name. The release commits on `main` carry the version file, the lock and the changelog and nothing else.
 
-  - **If the Unreleased section has content** (items under `### Added`, `### Changed`, `### Removed`, etc.): convert the Unreleased heading to `## [v{TARGET_VERSION}] - {TODAY'S DATE in YYYY-MM-DD}`, keeping all existing subsections and their content intact. Remove the Unreleased heading entirely — do **not** re-insert an empty `## [Unreleased]` section. Present the result to the user for approval.
+## CI on the release pull request
 
-  - **If the Unreleased section is empty**: remove it entirely, then proceed as if it were absent.
+- `guard-branches.yml` (`gate-main`) — the head branch into `main` must match `^release\/v[0-9]+\.[0-9]+\.[0-9]+$` exactly, so the release branch name is the only way in. Its `gate-release` job governs pull requests whose base is `dev` or begins `release/v` instead, and `protect-workflows` fires only when the author association is `CONTRIBUTOR`.
+- `version-check.yml` (pull requests to `main`) — the `pyproject.toml` version equals the version in the branch name. It asserts nothing about the version already on `main`. A head that is not a release branch does not slip past it: the `exit 0` in its first step ends that step alone, and the comparison that follows then fails on an empty branch version.
+- `changelog-check.yml` (pull requests to `main`, and only when the head starts with `release/v`) — `CHANGELOG.md` carries a `## [vX.Y.Z] - ` heading for the version in the branch name. It asserts nothing about `[Unreleased]`; leaving none behind is the play's rule, not CI's.
+- `lint-check.yml` (every pull request) — the ruff format, ruff lint, pyright and mypy merge checks on 3.11, 3.12 and 3.13, each leg installing with `make install`; the aggregator job `Lint (all versions)` is the single required status.
+- `tests-check.yml` (every pull request) — `make gha-tests` on the same Python matrix with `ENV: dev`.
+- `cla.yml` — the CLA assistant on `pull_request_target`, allowlisted for maintainers.
 
-  - **If the Unreleased section is absent**: run `git log main..HEAD --oneline` (or `git log --oneline -20` if on `main`) to review recent commits. Draft a changelog entry from those commits and propose it to the user for approval. Insert the approved entry right after the `# Changelog` heading, formatted as:
+Nothing in CI checks that `uv.lock` agrees with `pyproject.toml` — no `uv lock --locked` runs anywhere, and `make install` re-locks silently rather than failing — so the lock step above is the only thing keeping the two in step.
 
-    ```markdown
-    ## [v{TARGET_VERSION}] - {TODAY'S DATE in YYYY-MM-DD}
+## Particulars
 
-    - Item one
-    - Item two
-    ```
-
-This project does **not** use an `## [Unreleased]` placeholder — never add one. The user may accept, edit, or rewrite the proposed entry.
-
-## Step 7 — Validate Lint & Type Checks
-
-Run:
-
-```bash
-make agent-check
-```
-
-- **On success**: report and continue.
-- **On failure**: show the errors and ask the user how to proceed (fix issues, skip validation, or abort).
-
-## Step 8 — Review & Commit
-
-Present a full summary:
-
-- Target version: `v{TARGET_VERSION}`
-- Branch: `release/v{TARGET_VERSION}`
-- Files changed: `pyproject.toml`, `uv.lock`, `CHANGELOG.md`
-- Changelog entry preview
-
-Ask the user to confirm. On confirmation:
-
-1. Stage **only** `pyproject.toml`, `uv.lock`, and `CHANGELOG.md` — never use `git add .` or `git add -A`.
-2. Commit with message: `Release v{TARGET_VERSION}: <one-line changelog summary>`
-3. Show the commit result.
-
-Then offer (but do not automatically execute):
-
-- **Push** the branch to origin (`git push -u origin release/v{TARGET_VERSION}`)
-- **Create a PR** to `main` using `gh pr create`
-
-Wait for explicit user approval before pushing or creating a PR.
-
-## Rules
-
-- Never use `git add .` or `git add -A` — only stage `pyproject.toml`, `uv.lock`, and `CHANGELOG.md`.
-- Never push or create PRs without explicit user approval.
-- The `v` prefix appears in branch names and changelog headers, but **not** in `pyproject.toml`.
-- Always use today's date for new changelog entries (format: `YYYY-MM-DD`).
-- If any step fails or the user wants to abort, stop immediately — do not continue the workflow.
+- **The commit message carries a one-line summary**: `Release vX.Y.Z: <summary>`, which is where this repo departs from the play's bare `Release vX.Y.Z` and what its release commits on `main` read. Nothing in CI asserts it, so the summary is for the reader of the history.
+- **No pre-release form.** A head like `release/v0.18.0-rc.1` fails all three release gates rather than skipping them: `guard-branches.yml` refuses it outright, `version-check.yml` compares the version against an empty branch version, and `changelog-check.yml` runs on any `release/v` head and then rejects the name against its own `^release/v([0-9]+\.[0-9]+\.[0-9]+)$`. Ship a plain `X.Y.Z`.
+- **The changelog headings carry the `v`** — `## [vX.Y.Z] - YYYY-MM-DD` — which is exactly what `changelog-check.yml` greps for and what `github-release.yml` slices the Release notes out of. No `[Unreleased]` heading is left behind; the next change re-creates one.
+- **The release tags are lightweight**, created as a side effect of `gh release create` rather than by `git tag -a`. Always pass `--tags` when reading them, and expect no loud failure without it: one annotated tag, `v0.1.7`, was pushed by hand early in the repo's history and is still reachable, so a bare `git describe` answers with that ancient tag instead of refusing, and the number it prints is not the last release.
+- **`pipelex` is pinned exactly** — `pipelex[…]==A.B.C` in `[project].dependencies`, not a floor — so what a cookbook release usually promotes is that pin moving and the examples adapting to it. The pre-flight's log range is where to read which pin this release carries, and the changelog entry is mostly about that.
+- **No release follow-ups are armed automatically.** `ledger.toml` declares no `release_followups` for `pipelex-cookbook`, so filing the release item materializes no blocked tasks; anything this release owes another repo is filed by hand alongside it.


### PR DESCRIPTION
The repo's `/release` skill now carries only what is specific to `pipelex-cookbook`, and names the workspace release play (`docs/releasing.md` at the workspace root, `../docs/releasing.md` from this repo) for the procedure everyone follows. Gone from the skill is everything the play already does once for every repo: the `git status` pre-flight that offered to fold a dirty tree or unpushed commits into the release, the release branch created in place with a `checkout -b` (which the main-checkout guard now refuses outright), the numbered interactive walkthrough, and the push-and-open-a-pull-request tail. What remains is the part that cannot be regenerated from the play. The skill opens by naming the repo key `pipelex-cookbook`, the base `dev`, the pull request target `main`, and the release worktree `_pipelex-cookbook--release`.

Under the six headings the play reads by name, the skill now declares:

- **What ships** — nothing to any package registry; there is no publish workflow. The merge to `main` produces the GitHub Release and its lightweight tag, created by `github-release.yml` on push to `main`, along with how that workflow reads the version, slices the changelog for the notes, flattens nested bullets, and ships a Release with empty notes rather than failing when it finds no heading. The landing verifies the run, the Release and the tag.
- **Version files and the lock** — `pyproject.toml`'s `[project].version` is the one and only place the number is written, and it must stay the file's first `version = ` line at column zero because two workflows grep for it. `uv.lock` records the project's own version and is re-locked behind the bump with `make lock`. Nothing else is stamped: no badge, no `__version__`, and the requirements exports carry no cookbook version.
- **Gates** — `make agent-check` (it rewrites files, so what it touched joins the release commit; its `plxt` half is enforced nowhere else in CI) then `make agent-test`, with the caveat that the pull request's `make gha-tests` selects a different marker set, so green here is not a promise of a green matrix there.
- **The release commit** — the version file, the lock, the changelog, and each file `make agent-check` rewrote, staged by name.
- **CI on the release pull request** — `guard-branches.yml`, `version-check.yml`, `changelog-check.yml`, `lint-check.yml`, `tests-check.yml` and `cla.yml`, each with what it actually asserts and what it does not; plus the note that nothing in CI checks `uv.lock` against `pyproject.toml`, which is why the lock step is manual.
- **Particulars** — the `Release vX.Y.Z: <summary>` commit subject this repo uses instead of the play's bare subject, the refusal of any pre-release form (all three release gates reject `release/v0.18.0-rc.1` rather than skipping it), the `v`-carrying changelog headings, the lightweight tags and the one hand-pushed annotated tag that makes a bare `git describe` answer with an ancient number, the exact `pipelex[…]==A.B.C` pin whose promotion is usually what a cookbook release is about, and the absence of any armed release follow-ups.

The rewrite verified each survey line against the tree, as the item asked, and found the survey disagreeing in a few places. The survey recorded the gate as `make agent-check` alone, "lint + types, no tests" — the repo has `make agent-test` and a `tests-check.yml` running `make gha-tests` across 3.11, 3.12 and 3.13, so tests are a gate on both sides. It listed `github-release.yml` among the pull request checks — that workflow fires on push to `main`, so it belongs under "What ships" and is where it now sits — and it omitted `lint-check.yml`, `tests-check.yml` and `cla.yml`, which are now named. It described changelog handling in terms of `## [Unreleased]` / `## Unreleased` sections; what the tree enforces is the `## [vX.Y.Z] - YYYY-MM-DD` heading that `changelog-check.yml` greps for and `github-release.yml` slices, with nothing in CI asserting anything about `[Unreleased]` at all. The base and target the survey asked to verify are confirmed: base `dev`, pull request to `main`.

Closes L-260907-fe24c7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F72qvy4QBZHe7XX24QmcT


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts the `/release` skill down to `pipelex-cookbook`'s specifics. The skill previously ran the whole release interactively; it now defers to the workspace release play and keeps only what the play can't cover — dropping the git status pre-flight, in-place branch creation, numbered walkthrough, and push-and-open-PR tail.

**What the skill now declares**

- Repo key, base `dev`, PR target `main`, and the `_pipelex-cookbook--release` worktree.
- Merge to `main` publishes a GitHub Release and lightweight tag via `github-release.yml`; nothing ships to a package registry.
- Version lives in `pyproject.toml`'s first `version = ` line, with `uv.lock` re-locked behind it via `make lock`.
- Gates are `make agent-check` then `make agent-test`, with the caveat that the PR's `make gha-tests` selects a different marker set.
- Lists the six CI workflows on a release PR and what each asserts, and notes nothing in CI checks `uv.lock` against `pyproject.toml`.
- Particulars: `Release vX.Y.Z: <summary>` commit subject, rejection of pre-release forms, `v`-carrying changelog headings, lightweight tags, exact `pipelex[…]==A.B.C` pin, no armed release follow-ups.

**Corrections from the survey**

The rewrite verified the survey against the tree and fixed where they disagreed: tests are a gate on both sides (`make agent-test` and `tests-check.yml`), `github-release.yml` fires on push to `main` rather than on the PR, `lint-check.yml`, `tests-check.yml` and `cla.yml` were missing, and the changelog format is `## [vX.Y.Z] - YYYY-MM-DD` with nothing in CI asserting `[Unreleased]`.

Closes L-260907-fe24c7.

<sup>Written for commit 8837d181d842e5dc1e5827cd1e6ecb220e0da32e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/pipelex-cookbook/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

